### PR TITLE
Documentation for encoding a record

### DIFF
--- a/README
+++ b/README
@@ -25,6 +25,9 @@ USAGE
   writer = MARC::XMLWriter.new('marc.xml')
   writer.write(record)
   writer.close()
+  
+  # encoding a record
+  MARC::Writer.encode(record) # or record.to_marc
 
 INSTALLATION
 


### PR DESCRIPTION
I added documentation to the README, giving an example of two ways to encode a MARC object.
