### PR TITLE
Add new_from_s to Record and DataField

### DIFF
--- a/lib/marc/datafield.rb
+++ b/lib/marc/datafield.rb
@@ -92,7 +92,7 @@ module MARC
 
 
     # Returns a string representation of the field such as:
-    #  245 00 $aConsilience :$bthe unity of knowledge $cby Edward O. Wilson.
+    #  245 00 $a Consilience : $b the unity of knowledge $c by Edward O. Wilson. 
 
     def to_s
       str = "#{tag} "
@@ -100,6 +100,28 @@ module MARC
       @subfields.each { |subfield| str += subfield.to_s }
       return str
     end
+
+    # construct a datafield object from string representation (following field.to_s format)
+    # field = MARC::DataField.new_from_s(field_string)
+    def self.new_from_s(s)
+      str  = String.new s # copy to protect s
+      tag  = str[0..2]
+      df   = self.new(tag)
+      ind1 = str[4]
+      ind2 = str[5]
+      str.slice!(0..6) # remove tag, inds and space
+
+      df.indicator1 = ind1
+      df.indicator2 = ind2
+      
+      subs = str.split(/\B\$([a-z0-9]) /).map(&:rstrip)
+      subs.shift
+      subs.each_slice(2) do |subfield|
+        df.append(MARC::Subfield.new(subfield[0], subfield[1]))
+      end
+
+      return df      
+    end    
 
     # Turn into a marc-hash structure
     def to_marchash

--- a/lib/marc/record.rb
+++ b/lib/marc/record.rb
@@ -265,6 +265,30 @@ module MARC
       return str
     end
 
+    # construct a record object from a string representation (following record.to_s format)
+    # record = MARC::Record.new_from_s(record_string)
+    def self.new_from_s(s)
+      r = self.new
+      fields = s.split "\n"
+      leader = fields.shift
+      leader.slice!(0..6) # remove "LEADER " prefix
+      r.leader = leader
+
+      fields.each do |field|
+        tag = field[0..2]
+
+        if tag.to_i < 10
+          cf = MARC::ControlField.new(tag)
+          field.slice!(0..3) # remove tag and space
+          cf.value = field
+          r.append cf
+        else
+          r.append MARC::DataField.new_from_s(field)
+        end
+      end
+
+      return r
+    end
 
     # For testing if two records can be considered equal.
 

--- a/test/tc_datafield.rb
+++ b/test/tc_datafield.rb
@@ -60,4 +60,9 @@ class TestField < Test::Unit::TestCase
         assert_equal(f['b'], 'Bar')
     end
 
+    def test_new_from_s
+        field_str = '245 10 $a ActivePerl with ASP and ADO / $c Tobias Martinsson. '
+        assert_equal(field_str, MARC::DataField.new_from_s(field_str).to_s)
+    end    
+
 end

--- a/test/tc_record.rb
+++ b/test/tc_record.rb
@@ -13,10 +13,10 @@ class TestRecord < Test::Unit::TestCase
       doc = r.to_xml
       assert_kind_of REXML::Element, doc
       if RUBY_VERSION < '1.9.0'
-        assert_equal "<record xmlns='http://www.loc.gov/MARC21/slim'><leader>      Z   22        4500</leader><datafield tag='100' ind1='2' ind2='0'><subfield code='a'>Thomas, Dave</subfield></datafield><datafield tag='245' ind1='0' ind2='4'><subfield code='The Pragmatic Programmer'></subfield></datafield></record>", doc.to_s
+        assert_equal "<record xmlns='http://www.loc.gov/MARC21/slim'><leader>      Z   22        4500</leader><datafield tag='100' ind1='2' ind2='0'><subfield code='a'>Thomas, Dave</subfield></datafield><datafield tag='245' ind1='0' ind2='4'><subfield code='a'>The Pragmatic Programmer</subfield></datafield></record>", doc.to_s
       else
         # REXML inexplicably sorts the attributes alphabetically in Ruby 1.9
-        assert_equal "<record xmlns='http://www.loc.gov/MARC21/slim'><leader>      Z   22        4500</leader><datafield ind1='2' ind2='0' tag='100'><subfield code='a'>Thomas, Dave</subfield></datafield><datafield ind1='0' ind2='4' tag='245'><subfield code='The Pragmatic Programmer'></subfield></datafield></record>", doc.to_s        
+        assert_equal "<record xmlns='http://www.loc.gov/MARC21/slim'><leader>      Z   22        4500</leader><datafield ind1='2' ind2='0' tag='100'><subfield code='a'>Thomas, Dave</subfield></datafield><datafield ind1='0' ind2='4' tag='245'><subfield code='a'>The Pragmatic Programmer</subfield></datafield></record>", doc.to_s        
       end
     end
 
@@ -69,7 +69,7 @@ class TestRecord < Test::Unit::TestCase
     def get_record
         r = MARC::Record.new()
         r.append(MARC::DataField.new('100', '2', '0', ['a', 'Thomas, Dave'])) 
-        r.append(MARC::DataField.new('245', '0', '4', ['The Pragmatic Programmer']))
+        r.append(MARC::DataField.new('245', '0', '4', ['a', 'The Pragmatic Programmer']))
         return r
     end
     
@@ -109,6 +109,12 @@ class TestRecord < Test::Unit::TestCase
       five_hundreds = r2.fields('500')
       assert_equal(five_hundreds.first['a'], '"Contemporary blues" interpretations of previously released songs; written by Bob Dylan.')
       assert_equal(five_hundreds.last['a'], 'Composer and program notes in container.')
+    end
+
+    def test_new_from_s
+      r = get_record
+      s = r.to_s
+      assert_equal(s, MARC::Record.new_from_s(s).to_s)
     end
 
 end

--- a/test/test.xml
+++ b/test/test.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0'?>
+<?xml-stylesheet type="text/xsl" href="style.xsl"?>
+<collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
+<record><leader>00925njm  22002777a 4500</leader><controlfield tag='007'>sdubumennmplu</controlfield><datafield ind1='0' ind2='4' tag='245'><subfield code='a'>The Great Ray Charles</subfield><subfield code='h'>[sound recording].</subfield></datafield></record>
+</collection>


### PR DESCRIPTION
Added new method (self.new_from_s) to Record and DataField to
provide a convenient, round-trip compatible way to construct
those objects from a string representation (following the
existing to_s format). Tests included.

To date have been monkey patching these in but perhaps someone
else will also find these useful?

Thanks for consideration and for ruby-marc!