### PR TITLE
Doc, spec, and fix how MARC::Writer handles too-long records

### DIFF
--- a/lib/marc/writer.rb
+++ b/lib/marc/writer.rb
@@ -7,13 +7,22 @@ module MARC
   # The MARC binary format only allows records that are total 99999 bytes long,
   # due to size of a length field in the record.
   #
-  # By default, the Writer will write these records out anyway, filling
-  # in any binary length/offset slots with all 0's, if they are not
-  # wide enough to hold the true value. These records are illegal, but
-  # but can still be read back in using the MARC::ForgivingReader
+  # By default, the Writer will raise a MARC::Exception when encountering
+  # in-memory records that are too long to be legally written out as ISO 2709
+  # binary.
+
+  # However, if you set `allow_oversized` to true, then the Writer will
+  # write these records out anyway, filling in any binary length/offset slots
+  # with all 0's, if they are not wide enough to hold the true value.
+  # While these records are illegal, they can still be read back in using
+  # the MARC::ForgivingReader, as well as other platform MARC readers
+  # in tolerant mode.
   #
   # If you set `allow_oversized` to false on the Writer, a MARC::Exception
-  # will be raised instead, if you try to write an oversized record. 
+  # will be raised instead, if you try to write an oversized record.
+  #
+  #    writer = Writer.new(some_path)
+  #    writer.allow_oversized = true
   class Writer
     attr_accessor :allow_oversized
 
@@ -28,7 +37,7 @@ module MARC
       else
         throw "must pass in file name or handle"
       end
-      self.allow_oversized = true
+      self.allow_oversized = false
     end
 
 
@@ -49,9 +58,9 @@ module MARC
     # a static method that accepts a MARC::Record object
     # and returns the record encoded as MARC21 in transmission format
     #
-    # Second arg allow_oversized, default true, set to false
+    # Second arg allow_oversized, default false, set to true
     # to raise on MARC record that can't fit into ISO 2709. 
-    def self.encode(record, allow_oversized = true)
+    def self.encode(record, allow_oversized = false)
       directory = ''
       fields = ''
       offset = 0

--- a/test/tc_writer.rb
+++ b/test/tc_writer.rb
@@ -59,6 +59,7 @@ class WriterTest < Test::Unit::TestCase
 
       wbuffer = StringIO.new("", "w")
       writer = MARC::Writer.new(wbuffer)
+      writer.allow_oversized = true
 
       writer.write(too_long_record)
       writer.close
@@ -82,6 +83,7 @@ class WriterTest < Test::Unit::TestCase
       good_record.append MARC::DataField.new("500", ' ', ' ', ['a', 'A short record'])
       wbuffer = StringIO.new("", "w")
       writer = MARC::Writer.new(wbuffer)
+      writer.allow_oversized = true
 
       writer.write(good_record)
       writer.write(too_long_record)
@@ -105,7 +107,6 @@ class WriterTest < Test::Unit::TestCase
 
       wbuffer = StringIO.new("", "w")
       writer = MARC::Writer.new(wbuffer)
-      writer.allow_oversized = false
 
       assert_raise(MARC::Exception) do
         writer.write too_long_record


### PR DESCRIPTION
In Master, a too-long record written with Marc::Writer winds up putting all 6 bytes in a space in leader that's supposed to be 5 bytes, messing up the whole leader, and making the entire record unreadable by likely most any marc reader. 

(I was wrong before, when I thought that it output a record with truncated length/offset values, that would still be readable by various forgiving marc readers on various platforms). 

Obviously that is a completely corrupt record. 
## New tested and doc'd behavior

In this branch, instead, there are two options: allow_oversized records or not. 

In strict mode (not allow_oversized), an exception is raised if the marc record is too long to be serialized in iso 2709 binary. 

In allow_oversized mode, if a length/offsets that  takes up too many bytes is encountered, it is written out as "00000" -- obviously impossible, but the right number of digits, to not  make the marc record completely unintelligible. 

The MARC::ForgivingReader could ALREADY read this kind of record, with no changes -- although there were no tests for this, there are now. 

 I _think_ Marc4J reader in permissive mode can also read this kind fo record, and maybe even the python marc record -- I investigated this a couple years ago, but could be wrong in my memory. 
## Default behavior?

Question on what the default behavior should be. 

Currently, if you use a Writer to write out a too long record, it does NOT raise, but writes out a completley unintelligible record. 

New beahvior will be two choices: 1) Raise, 2) Write out a record which, while illegal, is still readable by ForgivingReader. 

Which should be default?  If we didn't have to care about backwards compat?  For real, where we might have to care about backwards compat?

I lean toward NOT raising being default, since current behavior does not raise.  That is what this branch does. 
