### PR TITLE
fields.freeze can make a Record immutable and avoid accidental reindex

### DIFF
--- a/test/tc_record.rb
+++ b/test/tc_record.rb
@@ -139,7 +139,19 @@ class TestRecord < Test::Unit::TestCase
       assert r['500'], "New 505 directly added to #fields is picked up"
     end
 
+    def test_frozen_fieldmap
+      r = MARC::Record.new
+      r.fields.push MARC::DataField.new('500', ' ', ' ', ['a', 'notes'])
 
+      r.fields.freeze
+
+      r.fields.inspect
+      r.fields
+      assert ! r.fields('500').empty?
+
+      assert r.fields.instance_variable_get("@clean"), "FieldMap still marked clean"
+
+    end
 
 
 end


### PR DESCRIPTION
What do you guys think about this solution, @rsinger, @billdueber ?  

Basically based on rsinger's idea, but even further simplified, seems pretty correct to me. Completely backwards compat, doesn't get in your way if you don't need it, easy to understand the API, three lines of code. 
