### PR TITLE
Rename MARC::Field to MARC::ControlField

### DIFF
--- a/lib/marc/xmlwriter.rb
+++ b/lib/marc/xmlwriter.rb
@@ -137,7 +137,7 @@ module MARC
           control_element = REXML::Element.new("controlfield")
           
           # We need a marker for invalid tag values (we use 000)
-          unless field.tag.match(ctrlFieldTag) or MARC::Field.control_tag?(ctrlFieldTag)
+          unless field.tag.match(ctrlFieldTag) or MARC::ControlField.control_tag?(ctrlFieldTag)
             field.tag = "00z"
           end
           


### PR DESCRIPTION
MARC::Field does not exist.

/home/boutros/.rvm/gems/ruby-2.1.1/gems/marc-0.8.1/lib/marc/xmlwriter.rb:140:in `block in encode': uninitialized constant MARC::Field (NameError)

Maybe left after a renaming/refactoring?

I don't know, I just started to use this library.
