### PR TITLE
Change tests to work using minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,4 @@
 source 'https://rubygems.org'
 
-group :test do
-  if RUBY_VERSION != '1.8.7'
-    gem 'nokogiri'
-  end
-  gem 'rake'
-  gem 'rdoc'
-  gem 'xml-simple'
-end  
-
 # Specify your gem's dependencies in ..gemspec
 gemspec

--- a/marc.gemspec
+++ b/marc.gemspec
@@ -20,8 +20,14 @@ spec = Gem::Specification.new do |s|
   s.test_file     = 'test/ts_marc.rb'
   s.bindir        = 'bin'
 
-  s.add_dependency "ensure_valid_encoding"  
+  s.add_dependency "ensure_valid_encoding"
   s.add_dependency "scrub_rb", ">= 1.0.1", "< 2" # backport for ruby 2.1 String#scrub
-
   s.add_dependency "unf" # unicode normalization
+  s.add_dependency 'nokogiri', '>=1.6'
+
+  s.add_development_dependency 'minitest', '~>5'
+  s.add_development_dependency 'rake', '~>10'
+  s.add_development_dependency 'xml-simple', '>=1.1'
+
+
 end

--- a/test/marc8/tc_marc8_mapping.rb
+++ b/test/marc8/tc_marc8_mapping.rb
@@ -1,8 +1,10 @@
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative '../test_helper'
 require 'marc'
 require 'marc/marc8/map_to_unicode'
 
-class TestMarc8Mapping < Test::Unit::TestCase
+class TestMarc8Mapping < Minitest::Test
   def test_codesets_just_exist
     assert MARC::Marc8::MapToUnicode::CODESETS
     assert MARC::Marc8::MapToUnicode::CODESETS[0x34]

--- a/test/marc8/tc_to_unicode.rb
+++ b/test/marc8/tc_to_unicode.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require 'test/unit'
+require_relative '../test_helper'
 require 'marc'
 
 require 'marc/marc8/to_unicode'
@@ -10,7 +10,7 @@ require 'unf'
 if "".respond_to?(:encoding)
 
 
-  class TestMarc8ToUnicode < Test::Unit::TestCase
+  class TestMarc8ToUnicode < Minitest::Test
     def test_empty_string
       value = MARC::Marc8::ToUnicode.new.transcode("")
       assert_equal "UTF-8", value.encoding.name
@@ -32,9 +32,9 @@ if "".respond_to?(:encoding)
 
     def test_lots_of_marc8_test_cases
       # Heap of test cases taken from pymarc, which provided these
-      # two data files, marc8 and utf8, with line-by-line correspondences. 
+      # two data files, marc8 and utf8, with line-by-line correspondences.
       #
-      # For now, we have NOT included proprietary III encodings in our test data! 
+      # For now, we have NOT included proprietary III encodings in our test data!
       utf8_file   = File.open( File.expand_path("../data/test_utf8.txt", __FILE__), "r:UTF-8")
       marc8_file  = File.open( File.expand_path("../data/test_marc8.txt", __FILE__), "r:binary")
 
@@ -55,7 +55,7 @@ if "".respond_to?(:encoding)
 
           assert_equal utf8, converted, "Test data line #{i}, expected converted to match provided utf8"
         end
-      rescue EOFError => each 
+      rescue EOFError => each
         # just means the file was over, no biggie
         assert i > 1500, "Read as many lines as we expected to, at least 1500"
       rescue Exception => e
@@ -82,23 +82,23 @@ if "".respond_to?(:encoding)
       assert_equal unicode_d,  converter.transcode(marc8, :normalization => :nfd)
       assert_equal unicode_kd, converter.transcode(marc8, :normalization => :nfkd)
 
-      # disable normalization for performance or something, we won't end up with NFC. 
+      # disable normalization for performance or something, we won't end up with NFC.
       refute_equal unicode_c, converter.transcode(marc8, :normalization => nil)
     end
 
     def test_expand_ncr
       converter = MARC::Marc8::ToUnicode.new
-      
+
       marc8_ncr = "Weird &#x200F; &#xFFFD; but these aren't changed #x2000; &#200F etc."
       assert_equal "Weird \u200F \uFFFD but these aren't changed #x2000; &#200F etc.", converter.transcode(marc8_ncr)
       assert_equal marc8_ncr, converter.transcode(marc8_ncr, :expand_ncr => false), "should not expand NCR if disabled"
-    end  
+    end
 
     def test_bad_byte
       converter = MARC::Marc8::ToUnicode.new
 
       bad_marc8 = "\e$1!PVK7oi$N!Q1!G4i$N!0p!Q+{6924f6}\e(B"
-      assert_raise(Encoding::InvalidByteSequenceError) {
+      assert_raises(Encoding::InvalidByteSequenceError) {
         value = converter.transcode(bad_marc8)
       }
     end
@@ -112,9 +112,9 @@ if "".respond_to?(:encoding)
       assert_equal "UTF-8", value.encoding.name
       assert value.valid_encoding?
 
-      assert value.include?("\uFFFD"), "includes replacement char"    
+      assert value.include?("\uFFFD"), "includes replacement char"
       # coalescing multiple replacement chars at end, could change
-      # to not do so, important thing is at least one is there. 
+      # to not do so, important thing is at least one is there.
       assert_equal "米国の統治の仕組�", value
     end
 
@@ -150,5 +150,5 @@ if "".respond_to?(:encoding)
   end
 else
   require 'pathname'
-  $stderr.puts "\nTests not being run in ruby 1.9.x, skipping #{Pathname.new(__FILE__).basename}\n\n"  
+  $stderr.puts "\nTests not being run in ruby 1.9.x, skipping #{Pathname.new(__FILE__).basename}\n\n"
 end

--- a/test/tc_controlfield.rb
+++ b/test/tc_controlfield.rb
@@ -1,7 +1,9 @@
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative './test_helper'
 require 'marc'
 
-class TestField < Test::Unit::TestCase
+class TestField < Minitest::Test
 
   def test_control
     control = MARC::ControlField.new('005', 'foobarbaz')
@@ -9,39 +11,47 @@ class TestField < Test::Unit::TestCase
   end
 
   def test_field_as_control
-    assert_raise(MARC::Exception) do
+    assert_raises(MARC::Exception) do
       # can't have a field with a tag < 010
-      field = MARC::DataField.new('007') 
+      field = MARC::DataField.new('007')
     end
   end
 
   def test_alpha_control_field
-    assert_raise(MARC::Exception) do
+    assert_raises(MARC::Exception) do
       # can't have a field with a tag < 010
-      field = MARC::ControlField.new('DDD') 
+      field = MARC::ControlField.new('DDD')
     end
   end
-  
+
   def test_extra_control_field
     MARC::ControlField.control_tags << 'FMT'
-    assert_nothing_raised do
-       field = MARC::ControlField.new('FMT') 
+    begin
+      field = MARC::ControlField.new('FMT')
+      assert_equal(true, true, "FMT added as legal control field")
+    rescue => e
+      refute_equal(true, true, "FMT added as legal control field")
     end
-    assert_raise(MARC::Exception) do
-      field = MARC::DataField.new('FMT') 
+
+
+    assert_raises(MARC::Exception) do
+      field = MARC::DataField.new('FMT')
     end
     MARC::ControlField.control_tags.delete('FMT')
-    assert_nothing_raised do
-       field = MARC::DataField.new('FMT') 
+    begin
+      field = MARC::DataField.new('FMT')
+      assert_equal(true, true, "FMT removed as legal control field")
+    rescue => e
+      refute_equal(true, true, "FMT removed as legal control field")
     end
-    assert_raise(MARC::Exception) do
-      field = MARC::ControlField.new('FMT') 
+    assert_raises(MARC::Exception) do
+      field = MARC::ControlField.new('FMT')
     end
-    
+
   end
 
   def test_control_as_field
-    assert_raise(MARC::Exception) do
+    assert_raises(MARC::Exception) do
       # can't have a control with a tag > 009
       f = MARC::ControlField.new('245')
     end

--- a/test/tc_datafield.rb
+++ b/test/tc_datafield.rb
@@ -1,7 +1,9 @@
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative './test_helper'
 require 'marc'
 
-class TestField < Test::Unit::TestCase
+class TestField < Minitest::Test
 
     def test_tag
         f1 = MARC::DataField.new('100')
@@ -10,7 +12,7 @@ class TestField < Test::Unit::TestCase
         assert_equal('100', f2.tag)
         assert_equal(f1, f2)
         f3 = MARC::DataField.new('245')
-        assert_not_equal(f1, f3)
+        refute_equal(f1, f3)
     end
 
     def test_alphabetic_tag
@@ -30,30 +32,30 @@ class TestField < Test::Unit::TestCase
         assert_equal('1', f2.indicator2)
         assert_equal(f1, f2)
         f3 = MARC::DataField.new(tag='100', i1='1', i2='1')
-        assert_not_equal(f1, f3)
+        refute_equal(f1, f3)
     end
 
     def test_subfields
-        f1 = MARC::DataField.new('100', '0', '1', 
+        f1 = MARC::DataField.new('100', '0', '1',
             MARC::Subfield.new('a', 'Foo'),
             MARC::Subfield.new('b', 'Bar') )
         assert_equal("100 01 $a Foo $b Bar ", f1.to_s)
         assert_equal("FooBar", f1.value)
-        f2 = MARC::DataField.new('100', '0', '1', 
+        f2 = MARC::DataField.new('100', '0', '1',
             MARC::Subfield.new('a', 'Foo'),
             MARC::Subfield.new('b', 'Bar') )
         assert_equal(f1,f2)
-        f3 = MARC::DataField.new('100', '0', '1', 
+        f3 = MARC::DataField.new('100', '0', '1',
             MARC::Subfield.new('a', 'Foo'),
             MARC::Subfield.new('b', 'Bez') )
-        assert_not_equal(f1,f3)
+        refute_equal(f1,f3)
     end
 
     def test_subfield_shorthand
         f  = MARC::DataField.new('100', '0', '1', ['a', 'Foo'], ['b', 'Bar'])
         assert_equal('100 01 $a Foo $b Bar ', f.to_s)
     end
-            
+
 
     def test_iterator
         field = MARC::DataField.new('100', '0', '1', ['a', 'Foo'],['b', 'Bar'],
@@ -62,7 +64,7 @@ class TestField < Test::Unit::TestCase
         field.each {|x| count += 1}
         assert_equal(count,3)
     end
-    
+
     def test_lookup_shorthand
         f  = MARC::DataField.new('100', '0', '1', ['a', 'Foo'], ['b', 'Bar'])
         assert_equal(f['b'], 'Bar')

--- a/test/tc_dublincore.rb
+++ b/test/tc_dublincore.rb
@@ -1,7 +1,9 @@
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative './test_helper'
 require 'marc'
 
-class DublinCoreTest < Test::Unit::TestCase
+class DublinCoreTest < Minitest::Test
 
     def test_mapping
         reader = MARC::Reader.new('test/batch.dat')

--- a/test/tc_hash.rb
+++ b/test/tc_hash.rb
@@ -1,8 +1,10 @@
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative './test_helper'
 require 'marc'
 require 'rubygems'
 
-class TestHash < Test::Unit::TestCase
+class TestHash < Minitest::Test
 
   def test_to_hash
     raw = IO.read('test/one.dat')
@@ -21,6 +23,6 @@ class TestHash < Test::Unit::TestCase
       assert_equal(r,x)
     end
   end
-  
-  
+
+
 end

--- a/test/tc_marchash.rb
+++ b/test/tc_marchash.rb
@@ -1,8 +1,10 @@
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative './test_helper'
 require 'marc'
 require 'rubygems'
 
-class TestMARCHASH < Test::Unit::TestCase
+class TestMARCHASH < Minitest::Test
 
   def test_simple
     simple = {
@@ -10,7 +12,7 @@ class TestMARCHASH < Test::Unit::TestCase
       'version' => [1,0],
       'leader' => 'LEADER',
       'fields' => [
-        ['245', '1', '0', 
+        ['245', '1', '0',
           [
             ['a', 'TITLE'],
             ['b', 'SUBTITLE']
@@ -32,6 +34,6 @@ class TestMARCHASH < Test::Unit::TestCase
       assert_equal(r,x)
     end
   end
-  
-  
+
+
 end

--- a/test/tc_parsers.rb
+++ b/test/tc_parsers.rb
@@ -1,13 +1,15 @@
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative './test_helper'
 require 'marc'
 
-class ParsersTest < Test::Unit::TestCase
+class ParsersTest < Minitest::Test
   def test_parser_default
     assert_equal("rexml", MARC::XMLReader.parser)
     reader = MARC::XMLReader.new('test/one.xml')
     assert_kind_of(REXML::Parsers::PullParser, reader.parser)
   end
-  
+
   def test_set_nokogiri
     begin
       require 'nokogiri'
@@ -19,7 +21,7 @@ class ParsersTest < Test::Unit::TestCase
       assert_equal("rexml", MARC::XMLReader.parser)
       reader = MARC::XMLReader.new('test/one.xml', :parser=>'nokogiri')
       assert_kind_of(Nokogiri::XML::SAX::Parser, reader.parser)
-      assert_equal("rexml", MARC::XMLReader.parser)      
+      assert_equal("rexml", MARC::XMLReader.parser)
       MARC::XMLReader.parser=MARC::XMLReader::USE_NOKOGIRI
       assert_equal("nokogiri", MARC::XMLReader.parser)
       reader = MARC::XMLReader.new('test/one.xml')
@@ -27,12 +29,12 @@ class ParsersTest < Test::Unit::TestCase
       MARC::XMLReader.parser="nokogiri"
       assert_equal("nokogiri", MARC::XMLReader.parser)
       reader = MARC::XMLReader.new('test/one.xml')
-      assert_kind_of(Nokogiri::XML::SAX::Parser, reader.parser)      
+      assert_kind_of(Nokogiri::XML::SAX::Parser, reader.parser)
     rescue LoadError
       puts "\nNokogiri not available, skipping 'test_set_nokogiri'.\n"
     end
   end
-  
+
   def test_set_jrexml
     if defined? JRUBY_VERSION
       begin
@@ -42,7 +44,7 @@ class ParsersTest < Test::Unit::TestCase
         assert_equal("rexml", MARC::XMLReader.parser)
         reader = MARC::XMLReader.new('test/one.xml', :parser=>'jrexml')
         assert_kind_of(REXML::Parsers::PullParser, reader.parser)
-        assert_equal("rexml", MARC::XMLReader.parser)      
+        assert_equal("rexml", MARC::XMLReader.parser)
         MARC::XMLReader.parser=MARC::XMLReader::USE_JREXML
         assert_equal("jrexml", MARC::XMLReader.parser)
         reader = MARC::XMLReader.new('test/one.xml')
@@ -50,28 +52,28 @@ class ParsersTest < Test::Unit::TestCase
         MARC::XMLReader.parser="jrexml"
         assert_equal("jrexml", MARC::XMLReader.parser)
         reader = MARC::XMLReader.new('test/one.xml')
-        assert_kind_of(REXML::Parsers::PullParser, reader.parser)      
+        assert_kind_of(REXML::Parsers::PullParser, reader.parser)
       rescue LoadError
         puts "\njrexml not available, skipping 'test_set_jrexml'.\n"
       end
     else
       puts "\nTest not being run from JRuby, skipping 'test_set_jrexml'.\n"
     end
-  end  
-  
+  end
+
 def test_set_jstax
   if defined? JRUBY_VERSION
     begin
       assert_equal("rexml", MARC::XMLReader.parser)
       reader = MARC::XMLReader.new('test/one.xml')
       assert_kind_of(REXML::Parsers::PullParser, reader.parser)
-    
+
       reader = MARC::XMLReader.new('test/one.xml', :parser=>MARC::XMLReader::USE_JSTAX)
       assert_kind_of(Java::ComSunOrgApacheXercesInternalImpl::XMLStreamReaderImpl, reader.parser)
       assert_equal("rexml", MARC::XMLReader.parser)
       reader = MARC::XMLReader.new('test/one.xml', :parser=>'jstax')
       assert_kind_of(Java::ComSunOrgApacheXercesInternalImpl::XMLStreamReaderImpl, reader.parser)
-      assert_equal("rexml", MARC::XMLReader.parser)      
+      assert_equal("rexml", MARC::XMLReader.parser)
       MARC::XMLReader.parser=MARC::XMLReader::USE_JSTAX
       assert_equal("jstax", MARC::XMLReader.parser)
       reader = MARC::XMLReader.new('test/one.xml')
@@ -86,15 +88,15 @@ def test_set_jstax
   else
     puts "\nTest not being run from JRuby, skipping 'test_set_jstax'.\n"
   end
-end  
-  
+end
+
   def test_set_rexml
     reader = MARC::XMLReader.new('test/one.xml', :parser=>MARC::XMLReader::USE_REXML)
     assert_kind_of(REXML::Parsers::PullParser, reader.parser)
     assert_equal("rexml", MARC::XMLReader.parser)
     reader = MARC::XMLReader.new('test/one.xml', :parser=>'rexml')
     assert_kind_of(REXML::Parsers::PullParser, reader.parser)
-    assert_equal("rexml", MARC::XMLReader.parser)      
+    assert_equal("rexml", MARC::XMLReader.parser)
     MARC::XMLReader.parser=MARC::XMLReader::USE_REXML
     assert_equal("rexml", MARC::XMLReader.parser)
     reader = MARC::XMLReader.new('test/one.xml')
@@ -102,9 +104,9 @@ end
     MARC::XMLReader.parser="rexml"
     assert_equal("rexml", MARC::XMLReader.parser)
     reader = MARC::XMLReader.new('test/one.xml')
-    assert_kind_of(REXML::Parsers::PullParser, reader.parser)    
+    assert_kind_of(REXML::Parsers::PullParser, reader.parser)
   end
-  
+
   def test_set_magic
     best = choose_best_available_parser
     magic_parser = best[:parser]
@@ -114,7 +116,7 @@ end
     assert_equal("rexml", MARC::XMLReader.parser)
     reader = MARC::XMLReader.new('test/one.xml', :parser=>'magic')
     assert_kind_of(magic_parser, reader.parser)
-    assert_equal("rexml", MARC::XMLReader.parser)      
+    assert_equal("rexml", MARC::XMLReader.parser)
     MARC::XMLReader.parser=MARC::XMLReader::USE_BEST_AVAILABLE
     assert_equal("magic", MARC::XMLReader.parser)
     reader = MARC::XMLReader.new('test/one.xml')
@@ -122,9 +124,9 @@ end
     MARC::XMLReader.parser="magic"
     assert_equal("magic", MARC::XMLReader.parser)
     reader = MARC::XMLReader.new('test/one.xml')
-    assert_kind_of(magic_parser, reader.parser)    
-  end  
-  
+    assert_kind_of(magic_parser, reader.parser)
+  end
+
   def test_parser_set_convenience_methods
     best = choose_best_available_parser
     parser = best[:parser]
@@ -135,20 +137,20 @@ end
     assert_kind_of(parser, reader.parser)
     MARC::XMLReader.rexml!
     reader = MARC::XMLReader.new('test/one.xml')
-    assert_kind_of(REXML::Parsers::PullParser, reader.parser)   
+    assert_kind_of(REXML::Parsers::PullParser, reader.parser)
     if parser_name == 'nokogiri'
       MARC::XMLReader.nokogiri!
       reader = MARC::XMLReader.new('test/one.xml')
-      assert_kind_of(Nokogiri::XML::SAX::Parser, reader.parser)   
+      assert_kind_of(Nokogiri::XML::SAX::Parser, reader.parser)
     else
       puts "\nNokogiri not loaded, skipping convenience method test.\n"
     end
     if defined? JRUBY_VERSION
       begin
-        require 'jrexml'    
+        require 'jrexml'
         MARC::XMLReader.jrexml!
         reader = MARC::XMLReader.new('test/one.xml')
-        assert_kind_of(REXML::Parsers::PullParser, reader.parser) 
+        assert_kind_of(REXML::Parsers::PullParser, reader.parser)
       rescue LoadError
         puts "\njrexml not available, skipping convenience method test.\n"
       end
@@ -156,15 +158,15 @@ end
       puts "\nTest not being run from JRuby, skipping jrexml convenience method test.\n"
     end
   end
-    
+
   def teardown
     MARC::XMLReader.parser=MARC::XMLReader::USE_REXML
   end
-  
+
   def choose_best_available_parser
     parser_name = nil
     parser = nil
-    unless parser    
+    unless parser
       begin
         require 'nokogiri'
         parser_name = 'nokogiri'
@@ -198,15 +200,15 @@ end
             parser_name = 'jrexml'
             parser = REXML::Parsers::PullParser
           rescue LoadError
-          end        
+          end
         end
       end
       unless parser
         parser = REXML::Parsers::PullParser
         parser_name = 'rexml'
       end
-    end    
+    end
     return {:parser=>parser, :parser_name=>parser_name}
   end
-  
+
 end

--- a/test/tc_reader.rb
+++ b/test/tc_reader.rb
@@ -1,9 +1,11 @@
 # -*- encoding: utf-8 -*-
 
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative './test_helper'
 require 'marc'
 
-class ReaderTest < Test::Unit::TestCase
+class ReaderTest < Minitest::Test
 
   def test_batch
     reader = MARC::Reader.new('test/batch.dat')
@@ -18,19 +20,19 @@ class ReaderTest < Test::Unit::TestCase
     reader.each { count += 1 }
     assert_equal(10, count)
   end
-  
+
   def test_loose_utf8
-    # This isn't actually a corrupt file, but it is utf8, 
+    # This isn't actually a corrupt file, but it is utf8,
     # and I have some reason to believe forgiving reader isn't
-    # working properly with UTF8 in ruby 1.9, so testing it. 
+    # working properly with UTF8 in ruby 1.9, so testing it.
     reader = MARC::ForgivingReader.new('test/utf8.marc')
     count = 0
     reader.each { count += 1 }
     assert_equal(1, count)
   end
-  
+
   def test_loose_unimarc
-    # Unimarc might use a different record seperator? Let's make sure it works. 
+    # Unimarc might use a different record seperator? Let's make sure it works.
     reader = MARC::Reader.new(File.open('test/cp866_unimarc.marc', 'r:cp866'))
     count = 0
     reader.each {|a| count += 1 }
@@ -72,14 +74,14 @@ class ReaderTest < Test::Unit::TestCase
     records = reader.find_all { |r| r =~ /Foo/ }
     assert_equal(0, records.length)
   end
-  
+
   def test_binary_enumerator
     reader = MARC::Reader.new('test/batch.dat')
     iter = reader.each
     r = iter.next
     assert_instance_of(MARC::Record, r)
     9.times {iter.next} # total of ten records
-    assert_raises(StopIteration) { iter.next }  
+    assert_raises(StopIteration) { iter.next }
   end
 
   def test_each_raw

--- a/test/tc_reader_char_encodings.rb
+++ b/test/tc_reader_char_encodings.rb
@@ -1,6 +1,8 @@
 # -*- encoding: utf-8 -*-
 
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative './test_helper'
 require 'marc'
 
 require 'stringio'
@@ -11,42 +13,42 @@ require 'stringio'
 # (becuase the func they are testing is no-op on 1.9).
 
 if "".respond_to?(:encoding)
-  
-  class ReaderCharEncodingsTest < Test::Unit::TestCase
+
+  class ReaderCharEncodingsTest < Minitest::Test
     ####
     # Helper methods for our tests
     #
     ####
-    
-    
+
+
     @@utf_marc_path = 'test/utf8.marc'
     # tests against record at test/utf8.marc
     def assert_utf8_right_in_utf8(record)
       assert_equal "UTF-8", record['245'].subfields.first.value.encoding.name
-            
+
       assert_equal "UTF-8", record['245'].to_s.encoding.name
-      
+
       assert_equal "UTF-8", record['245'].subfields.first.to_s.encoding.name
       assert_equal "UTF-8", record['245'].subfields.first.value.encoding.name
-      
+
       assert_equal "UTF-8", record['245']['a'].encoding.name
       assert record['245']['a'].start_with?("Photčhanānukrom")
     end
-    
-    # Test against multirecord just to be sure that works. 
+
+    # Test against multirecord just to be sure that works.
     # the multirecord file is just two concatenated copies
-    # of the single one. 
+    # of the single one.
     @@cp866_marc_path = "test/cp866_multirecord.marc"
     # assumes record in test/cp866_unimarc.marc
     # Pass in an encoding name, using ruby's canonical name!
-    # "IBM866" not "cp866". "UTF-8". 
+    # "IBM866" not "cp866". "UTF-8".
     def assert_cp866_right(record, encoding = "IBM866")
       assert_equal(encoding, record['001'].value.encoding.name)
-      assert_equal(["d09d"], record['001'].value.encode("UTF-8").unpack('H4')) # russian capital N    
+      assert_equal(["d09d"], record['001'].value.encode("UTF-8").unpack('H4')) # russian capital N
     end
 
     @@bad_marc8_path = "test/bad_eacc_encoding.marc8.marc"
-    
+
 
     def assert_all_values_valid_encoding(record, encoding_name="UTF-8")
       record.fields.each do |field|
@@ -65,62 +67,67 @@ if "".respond_to?(:encoding)
     ####
     # end helper methods
     ####
-    
-    
+
+
     def test_unicode_load
       reader = MARC::Reader.new(@@utf_marc_path)
-      
+
       record = nil
-      
-      assert_nothing_raised { record = reader.first }
-      
+
+      begin
+        record = reader.first
+        assert_equal(true, true, "Unicode load worked")
+      rescue => e
+        refute_equal(true, true, "Unicode load worked")
+      end
+
       assert_utf8_right_in_utf8(record)
     end
-    
-    
+
+
     def test_unicode_decode_forgiving
       # two kinds of forgiving invocation, they shouldn't be different,
       # but just in case they have slightly different code paths, test em
-      # too. 
-      marc_string = File.open(@@utf_marc_path).read.force_encoding("utf-8")      
+      # too.
+      marc_string = File.open(@@utf_marc_path).read.force_encoding("utf-8")
       record = MARC::Reader.decode(marc_string, :forgiving => true)
       assert_utf8_right_in_utf8(record)
 
-      
+
       reader = MARC::ForgivingReader.new(@@utf_marc_path)
       record = reader.first
       assert_utf8_right_in_utf8(record)
     end
-    
+
     def test_unicode_forgiving_reader_passes_options
       # Make sure ForgivingReader accepts same options as MARC::Reader
       # We don't test them ALL though, just a sample.
-      # Tell it we're reading cp866, but trancode to utf8 for us. 
+      # Tell it we're reading cp866, but trancode to utf8 for us.
       reader = MARC::ForgivingReader.new(@@cp866_marc_path, :external_encoding => "cp866", :internal_encoding => "utf-8")
 
-      record = reader.first 
+      record = reader.first
 
       assert_cp866_right(record, "UTF-8")
     end
-  
+
     def test_explicit_encoding
       reader = MARC::Reader.new(@@cp866_marc_path, :external_encoding => 'cp866')
-      
+
       assert_cp866_right(reader.first, "IBM866")
     end
-    
+
     def test_bad_encoding_name_input
       reader = MARC::Reader.new(@@cp866_marc_path, :external_encoding => 'adadfadf')
       assert_raises ArgumentError do
         reader.first
       end
     end
-    
+
     def test_marc8_with_binary
-      # Marc8, if we want to keep it without transcoding, best we can do is read it in binary. 
+      # Marc8, if we want to keep it without transcoding, best we can do is read it in binary.
       reader = MARC::Reader.new('test/marc8_accented_chars.marc', :external_encoding => 'binary')
       record = reader.first
-   
+
       assert_equal "ASCII-8BIT", record['100'].subfields.first.value.encoding.name
     end
 
@@ -152,7 +159,7 @@ if "".respond_to?(:encoding)
     end
 
     def test_bad_marc8_raises
-      assert_raise(Encoding::InvalidByteSequenceError) do
+      assert_raises(Encoding::InvalidByteSequenceError) do
         reader = MARC::Reader.new(@@bad_marc8_path, :external_encoding => 'MARC-8')
         record = reader.first
       end
@@ -162,35 +169,35 @@ if "".respond_to?(:encoding)
       reader = MARC::Reader.new(@@bad_marc8_path, :external_encoding => 'MARC-8', :invalid => :replace, :replace => "[?]")
       record = reader.first
 
-      assert_all_values_valid_encoding(record)      
-      
+      assert_all_values_valid_encoding(record)
+
       assert record['880']['a'].include?("[?]"), "includes specified replacement string"
     end
 
 
     def test_load_file_opened_with_external_encoding
       reader = MARC::Reader.new(File.open(@@cp866_marc_path, 'r:cp866'))
-      
-      record = reader.first  
+
+      record = reader.first
       # Make sure it's got the encoding it's supposed to.
-      
-      assert_cp866_right(record, "IBM866")      
+
+      assert_cp866_right(record, "IBM866")
     end
-    
+
     def test_explicit_encoding_beats_file_encoding
       reader = MARC::Reader.new(File.open(@@cp866_marc_path, 'r:utf-8'), :external_encoding => "cp866")
-      
+
       record = reader.first
-      
-      assert_cp866_right(record, "IBM866")            
+
+      assert_cp866_right(record, "IBM866")
     end
-    
+
     def test_from_string_with_utf8_encoding
       marc_file = File.open(@@utf_marc_path)
-      
+
       reader = MARC::Reader.new(marc_file)
       record = reader.first
-      
+
 
 
 
@@ -200,7 +207,7 @@ if "".respond_to?(:encoding)
     # bad bytes should be handled appropriately
     def test_from_string_utf8_with_bad_byte
       marc_file = File.open('test/marc_with_bad_utf8.utf8.marc')
-      
+
       reader = MARC::Reader.new(marc_file, :invalid => :replace)
 
       record = reader.first
@@ -219,127 +226,124 @@ if "".respond_to?(:encoding)
 
       assert record['520']['a'].include?("\uFFFD"), "Value with bad byte now has Unicode Replacement Char"
     end
-    
+
     def test_from_string_with_cp866
       marc_string = File.open(@@cp866_marc_path).read.force_encoding("cp866")
-      
+
       reader = MARC::Reader.new(StringIO.new(marc_string))
       record = reader.first
-      
-      assert_cp866_right(record, "IBM866")      
+
+      assert_cp866_right(record, "IBM866")
     end
-    
+
     def test_decode_from_string_with_cp866
       marc_string = File.open(@@cp866_marc_path).read.force_encoding("cp866")
-      
+
       record = MARC::Reader.decode(marc_string)
-      
-      assert_cp866_right(record, "IBM866")      
+
+      assert_cp866_right(record, "IBM866")
     end
-    
+
     def test_with_transcode
-      reader = MARC::Reader.new(@@cp866_marc_path, 
-        :external_encoding => 'cp866', 
+      reader = MARC::Reader.new(@@cp866_marc_path,
+        :external_encoding => 'cp866',
         :internal_encoding => 'UTF-8')
-      
-      record = reader.first 
-    
-      assert_cp866_right(record, "UTF-8")      
-      
+
+      record = reader.first
+
+      assert_cp866_right(record, "UTF-8")
+
     end
-    
+
     def test_with_binary_filehandle
       # about to recommend this as a foolproof way to avoid
       # ruby transcoding behind your back in docs, let's make
-      # sure it really works. 
+      # sure it really works.
       reader = MARC::Reader.new(File.open(@@cp866_marc_path, :external_encoding => "binary", :internal_encoding => "binary"),
         :external_encoding => "IBM866")
-        
+
       record = reader.first
       assert_cp866_right(record, "IBM866")
     end
-    
+
     def test_with_bad_source_bytes
-      reader = MARC::Reader.new('test/utf8_with_bad_bytes.marc', 
+      reader = MARC::Reader.new('test/utf8_with_bad_bytes.marc',
         :external_encoding => "UTF-8",
         :validate_encoding => true)
-      
-      assert_raise Encoding::InvalidByteSequenceError do
+
+      assert_raises Encoding::InvalidByteSequenceError do
         record = reader.first
       end
     end
-    
+
     def test_bad_source_bytes_with_replace
-      reader = MARC::Reader.new('test/utf8_with_bad_bytes.marc', 
+      reader = MARC::Reader.new('test/utf8_with_bad_bytes.marc',
         :external_encoding => "UTF-8", :invalid => :replace)
-      
-      record = nil
-      assert_nothing_raised do
-        record = reader.first
-      end
-      
-      # it should have the unicode replacement char where the bad
-      # byte was. 
-      assert_match '=> ' +  "\uFFFD" + '( <=', record['245']['a']      
-    end
-    
-    def test_bad_source_bytes_with_custom_replace
-      reader = MARC::Reader.new('test/utf8_with_bad_bytes.marc', 
-        :external_encoding => "UTF-8", :invalid => :replace, :replace => '')
-      
+
       record = reader.first
-      
-      # bad byte replaced with empty string, gone.     
-      assert_match '=> ( <=', record['245']['a']
-      
+
+      # it should have the unicode replacement char where the bad
+      # byte was.
+      assert_match '=> ' +  "\uFFFD" + '( <=', record['245']['a']
     end
-    
-    def test_default_internal_encoding      
+
+    def test_bad_source_bytes_with_custom_replace
+      reader = MARC::Reader.new('test/utf8_with_bad_bytes.marc',
+        :external_encoding => "UTF-8", :invalid => :replace, :replace => '')
+
+      record = reader.first
+
+      # bad byte replaced with empty string, gone.
+      assert_match '=> ( <=', record['245']['a']
+
+    end
+
+    def test_default_internal_encoding
       # Some people WILL be changing their Encoding.default_internal
-      # It's even recommended by wycats 
+      # It's even recommended by wycats
       # http://yehudakatz.com/2010/05/05/ruby-1-9-encodings-a-primer-and-the-solution-for-rails/
       # This will in some cases make ruby File object trans-code
       # by default. Trans-coding a serial marc binary can change the
-      # byte count and mess it up. 
+      # byte count and mess it up.
       #
       # But at present, because of the way the Reader is implemented reading
       # specific bytecounts, it _works_, although it does not _respect_
       # Encoding.default_internal. That's the best we can do right now,
-      # thsi test is important to ensure it stays at least this good. 
+      # thsi test is important to ensure it stays at least this good.
        begin
          original = Encoding.default_internal
          Encoding.default_internal = "UTF-8"
-         
+
          reader = MARC::Reader.new(File.open(@@cp866_marc_path, 'r:cp866'))
-       
+
          record = reader.first
-         
-         assert_cp866_right(record, "IBM866")                        
+
+         assert_cp866_right(record, "IBM866")
        ensure
          Encoding.default_internal = original
-       end      
+       end
     end
-    
+
     def test_default_internal_encoding_with_string_arg
       begin
          original = Encoding.default_internal
          Encoding.default_internal = "UTF-8"
-         
+
          reader = MARC::Reader.new(@@cp866_marc_path, :external_encoding => "cp866")
-       
+
          record = reader.first
-         
-         assert_cp866_right(record, "IBM866")                        
+
+         assert_cp866_right(record, "IBM866")
        ensure
          Encoding.default_internal = original
-       end    
+       end
     end
-      
+
   end
-  
-  
-  
+
+
+
 else
   require 'pathname'
-  $stderr.puts "\nTests not being run in ruby 1.9.x, skipping #{Pathname.new(__FILE__).basename}\n\n"  
+  $stderr.puts "\nTests not being run in ruby 1.9.x, skipping #{Pathname.new(__FILE__).basename}\n\n"
 end

--- a/test/tc_record.rb
+++ b/test/tc_record.rb
@@ -1,4 +1,6 @@
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative './test_helper'
 require 'marc'
 require 'xmlsimple'
 
@@ -9,12 +11,12 @@ require 'xmlsimple'
      end
      self
    end
-   a = XmlSimple.xml_in(a.to_s, 'normalisespace' => eq_all_but_zero) 
-   b = XmlSimple.xml_in(b.to_s, 'normalisespace' => eq_all_but_zero) 
+   a = XmlSimple.xml_in(a.to_s, 'normalisespace' => eq_all_but_zero)
+   b = XmlSimple.xml_in(b.to_s, 'normalisespace' => eq_all_but_zero)
    a == b
  end
 
-class TestRecord < Test::Unit::TestCase
+class TestRecord < Minitest::Test
 
     def test_constructor
         r = MARC::Record.new()
@@ -76,11 +78,11 @@ class TestRecord < Test::Unit::TestCase
 
     def get_record
         r = MARC::Record.new()
-        r.append(MARC::DataField.new('100', '2', '0', ['a', 'Thomas, Dave'])) 
+        r.append(MARC::DataField.new('100', '2', '0', ['a', 'Thomas, Dave']))
         r.append(MARC::DataField.new('245', '0', '4', ['The Pragmatic Programmer']))
         return r
     end
-    
+
     def test_field_index
       raw = IO.read('test/random_tag_order.dat')
       r = MARC::Record.new_from_marc(raw)
@@ -90,30 +92,30 @@ class TestRecord < Test::Unit::TestCase
       assert_kind_of(Array, r.fields('035'))
       raw2 = IO.read('test/random_tag_order2.dat')
       r2 = MARC::Record.new_from_marc(raw2)
-      assert_equal(6, r2.fields('500').length)     
+      assert_equal(6, r2.fields('500').length)
       # Test passing an array to Record#fields
-      assert_equal(3, r.fields(['500','505', '510', '511']).length) 
+      assert_equal(3, r.fields(['500','505', '510', '511']).length)
       # Test passing a Range to Record#fields
       assert_equal(9, r.fields(('001'..'099')).length)
     end
-    
+
     def test_field_index_order
       raw = IO.read('test/random_tag_order.dat')
-      r = MARC::Record.new_from_marc(raw)      
+      r = MARC::Record.new_from_marc(raw)
       notes = ['500','505','511']
       r.fields(('500'..'599')).each do |f|
         assert_equal(notes.pop, f.tag)
       end
-      
-      
+
+
       raw2 = IO.read('test/random_tag_order2.dat')
-      r2 = MARC::Record.new_from_marc(raw2)      
-      
+      r2 = MARC::Record.new_from_marc(raw2)
+
       fields = ['050','042','010','028','024','035','041','028','040','035','008','007','005','001']
       r2.each_by_tag(('001'..'099')) do |f|
         assert_equal(fields.pop, f.tag)
-      end      
-      
+      end
+
       five_hundreds = r2.fields('500')
       assert_equal(five_hundreds.first['a'], '"Contemporary blues" interpretations of previously released songs; written by Bob Dylan.')
       assert_equal(five_hundreds.last['a'], 'Composer and program notes in container.')
@@ -123,12 +125,12 @@ class TestRecord < Test::Unit::TestCase
     # Some tests for the internal FieldMap hash, normally
     # an implementation detail, but things get tricky and we need
     # tests to make sure we're good. Some of these you might
-    # change if you change FieldMap caching implementation or contract/API. 
+    # change if you change FieldMap caching implementation or contract/API.
     def test_direct_change_dirties_fieldmap
       # if we ask for #fields directly, and mutate it
       # with it's own methods, does any cache update?
       r = MARC::Record.new
-      assert r.fields('500').empty? 
+      assert r.fields('500').empty?
       r.fields.push MARC::DataField.new('500', ' ', ' ', ['a', 'notes'])
       assert ! r.fields('500').empty?, "New 505 directly added to #fields is picked up"
 

--- a/test/tc_subfield.rb
+++ b/test/tc_subfield.rb
@@ -1,7 +1,9 @@
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative './test_helper'
 require 'marc/subfield'
 
-class SubfieldTest < Test::Unit::TestCase
+class SubfieldTest < Minitest::Test
 
     def test_ok
         s = MARC::Subfield.new('a', 'foo')

--- a/test/tc_xml.rb
+++ b/test/tc_xml.rb
@@ -1,8 +1,10 @@
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative './test_helper'
 require 'marc'
 require 'stringio'
 
-class XMLTest < Test::Unit::TestCase
+class XMLTest < Minitest::Test
   def setup
     @parsers = [:rexml]
     begin
@@ -32,13 +34,13 @@ class XMLTest < Test::Unit::TestCase
   end
 
 
-  def test_xml_entities    
+  def test_xml_entities
     @parsers.each do | parser |
       puts "\nRunning test_xml_entities with: #{parser}.\n"
       xml_entities_test(parser)
     end
   end
-  
+
   def xml_entities_test(parser)
     r1 = MARC::Record.new
     r1 << MARC::DataField.new('245', '0', '0', ['a', 'foo & bar & baz'])
@@ -47,16 +49,16 @@ class XMLTest < Test::Unit::TestCase
 
     reader = MARC::XMLReader.new(StringIO.new(xml), :parser=>parser)
     r2 = reader.entries[0]
-    assert_equal 'foo & bar & baz', r2['245']['a']    
+    assert_equal 'foo & bar & baz', r2['245']['a']
   end
-  
+
   def test_batch
     @parsers.each do | parser |
       puts "\nRunning test_batch with: #{parser}.\n"
       batch_test(parser)
-    end    
+    end
   end
-  
+
   def batch_test(parser)
     reader = MARC::XMLReader.new('test/batch.xml', :parser=>parser)
     count = 0
@@ -66,12 +68,12 @@ class XMLTest < Test::Unit::TestCase
     end
     assert_equal(count, 2)
   end
-  
+
   def test_read_string
     @parsers.each do | parser |
       puts "\nRunning test_read_string with: #{parser}.\n"
       read_string_test(parser)
-    end  
+    end
   end
 
   def read_string_test(parser)
@@ -79,20 +81,20 @@ class XMLTest < Test::Unit::TestCase
     reader = MARC::XMLReader.new(StringIO.new(xml), :parser=>parser)
     assert_equal 2, reader.entries.length
   end
-  
+
   def test_non_numeric_fields
     @parsers.each do | parser |
       puts "\nRunning test_non_numeric_fields with: #{parser}.\n"
       non_numeric_fields_test(parser)
     end
   end
-    
+
   def non_numeric_fields_test(parser)
     reader = MARC::XMLReader.new('test/non-numeric.xml', :parser=>parser)
       count = 0
       record = nil
       reader.each do | rec |
-        count += 1 
+        count += 1
         record = rec
       end
       assert_equal(1, count)
@@ -104,9 +106,9 @@ class XMLTest < Test::Unit::TestCase
     @parsers.each do | parser |
       puts "\nRunning test_read_no_leading_zero_write_leading_zero with: #{parser}.\n"
       read_no_leading_zero_write_leading_zero_test(parser)
-    end    
+    end
   end
-  
+
   def read_no_leading_zero_write_leading_zero_test(parser)
     reader = MARC::XMLReader.new('test/no-leading-zero.xml', :parser=>parser)
     record = reader.to_a[0]
@@ -118,7 +120,7 @@ class XMLTest < Test::Unit::TestCase
       puts "\nRunning test_leader_from_xml with: #{parser}.\n"
       leader_from_xml_test(parser)
     end
-  end    
+  end
 
   def leader_from_xml_test(parser)
     reader = MARC::XMLReader.new('test/one.xml', :parser=>parser)
@@ -128,19 +130,19 @@ class XMLTest < Test::Unit::TestCase
     record = MARC::Record.new_from_marc(record.to_marc)
     assert_equal '00734njm a2200217uu 4500', record.leader
   end
-  
+
   def test_read_write
     @parsers.each do | parser |
       puts "\nRunning test_read_write with: #{parser}.\n"
       read_write_test(parser)
     end
-  end    
+  end
 
   def read_write_test(parser)
     record1 = MARC::Record.new
     record1.leader =  '00925njm  22002777a 4500'
     record1.append MARC::ControlField.new('007', 'sdubumennmplu')
-    record1.append MARC::DataField.new('245', '0', '4', 
+    record1.append MARC::DataField.new('245', '0', '4',
       ['a', 'The Great Ray Charles'], ['h', '[sound recording].'])
 
     writer = MARC::XMLWriter.new('test/test.xml', :stylesheet => 'style.xsl')
@@ -157,15 +159,15 @@ class XMLTest < Test::Unit::TestCase
 
     File.unlink('test/test.xml')
   end
-  
+
   def test_xml_enumerator
     @parsers.each do | parser |
       puts "\nRunning test_xml_enumerator with: #{parser}.\n"
       xml_enumerator_test(parser)
     end
   end
-  
-  
+
+
   def xml_enumerator_test(parser)
     # confusingly, test/batch.xml only has two records, not 10 like batch.dat
     reader = MARC::XMLReader.new('test/batch.xml', :parser=>parser)
@@ -173,9 +175,9 @@ class XMLTest < Test::Unit::TestCase
     r = iter.next
     assert_instance_of(MARC::Record, r)
     iter.next # total of two records
-    assert_raises(StopIteration) { iter.next }  
+    assert_raises(StopIteration) { iter.next }
   end
-  
+
 
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,2 @@
+require 'minitest/autorun'
+

--- a/test/ts_marc.rb
+++ b/test/ts_marc.rb
@@ -4,7 +4,9 @@
 # not already installed one
 $LOAD_PATH.unshift("lib")
 
-require 'test/unit'
+# encoding: UTF-8
+
+require_relative './test_helper'
 require 'test/tc_subfield'
 require 'test/tc_datafield'
 require 'test/tc_controlfield'


### PR DESCRIPTION
Minitest 5, the latest version, breaks this old test/unit compatibility. This is a simple search/replace to make the tests run under minitest5.

Besides the 'require' statements, I needed to slightly change the syntax for `assert_raises` and kind of punt for `assert_doesnt_raise` since minitest doesn't support it.
