### PR TITLE
Refactor the core classes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ group :test do
   gem 'rake'
   gem 'rdoc'
   gem 'xml-simple'
-end  
+  gem 'minitest', '~>4'
+end
 
 # Specify your gem's dependencies in ..gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require 'rake/testtask'
 require 'rdoc/task'
 require 'bundler/gem_tasks'
 
+require 'minitest/autorun'
 
 task :default => [:test]
 

--- a/lib/marc/controlfield.rb
+++ b/lib/marc/controlfield.rb
@@ -40,12 +40,7 @@ module MARC
     # Two control fields are equal if their tags and values are equal.
 
     def ==(other)
-      if @tag != other.tag
-        return false 
-      elsif @value != other.value
-        return false
-      end
-      return true
+      tag == other.tag && value = other.value
     end
 
     # turning it into a marc-hash element

--- a/lib/marc/controlfield.rb
+++ b/lib/marc/controlfield.rb
@@ -2,15 +2,15 @@ require 'set'
 
 module MARC
 
-  # MARC records contain control fields, each of which has a 
+  # MARC records contain control fields, each of which has a
   # tag and value. Tags for control fields must be in the
   # 001-009 range or be specially added to the @@control_tags Set
 
   class ControlField
-    
+
     # Initially, control tags are the numbers 1 through 9 or the string '000'
     @@control_tags = Set.new(%w{000 001 002 003 004 005 006 007 008 009})
- 
+
     def self.control_tags
       return @@control_tags
     end
@@ -26,7 +26,7 @@ module MARC
     # the value of the control field
     attr_accessor :value
 
-    # The constructor which must be passed a tag value and 
+    # The constructor which must be passed a tag value and
     # an optional value for the field.
 
     def initialize(tag,value='')
@@ -40,26 +40,26 @@ module MARC
     # Two control fields are equal if their tags and values are equal.
 
     def ==(other)
-      tag == other.tag && value = other.value
+      tag == other.tag && value == other.value
     end
 
     # turning it into a marc-hash element
     def to_marchash
       return [@tag, @value]
     end
-    
+
     # Turn the control field into a hash for MARC-in-JSON
     def to_hash
       return {@tag=>@value}
     end
-    
+
     def to_s
-      return "#{tag} #{value}" 
+      return "#{tag} #{value}"
     end
 
     def =~(regex)
       return self.to_s =~ regex
-    end      
+    end
 
   end
 

--- a/lib/marc/datafield.rb
+++ b/lib/marc/datafield.rb
@@ -125,11 +125,13 @@ module MARC
     # Turn the variable field and subfields into a hash for MARC-in-JSON
 
     def to_hash
-      field_hash = {@tag=>{'ind1'=>@indicator1,'ind2'=>@indicator2,'subfields'=>[]}}
-      self.each do |subfield|
-        field_hash[@tag]['subfields'] << {subfield.code=>subfield.value}
-      end
-      field_hash
+      { @tag =>
+        {
+         'ind1' => @indicator1,
+         'ind2' => @indicator2,
+         'subfields' => @subfields.map{|x| {x.code => x.value}}
+        }
+      }
     end
 
     # Add a subfield (MARC::Subfield) to the field

--- a/lib/marc/datafield.rb
+++ b/lib/marc/datafield.rb
@@ -1,11 +1,13 @@
+require 'forwardable'
+
 module MARC
-  # MARC records contain data fields, each of which has a tag, 
+  # MARC records contain data fields, each of which has a tag,
   # indicators and subfields. Tags for data fields must are all
   # three-character tags that are not control fields (generally,
   # any numeric tag greater than 009).
   #
   # Accessor attributes: tag, indicator1, indicator2
-  # 
+  #
   # DataField mixes in Enumerable to enable access to it's constituent
   # Subfield objects. For instance, if you have a DataField representing
   # a 856 tag, and want to find all 'z' subfields:
@@ -14,10 +16,14 @@ module MARC
   #
   # Also, the accessor 'subfields' is an array of MARC::Subfield objects
   # which can be accessed or modified by the client directly if
-  # neccesary. 
+  # neccesary.
 
   class DataField
     include Enumerable
+    extend Forwardable
+
+    # Enumerate over the subfields
+    def_delegators :@subfields, :each
 
     # The tag for the field
     attr_accessor :tag
@@ -33,38 +39,38 @@ module MARC
 
 
     # Create a new field with tag, indicators and subfields.
-    # Subfields are passed in as comma separated list of 
-    # MARC::Subfield objects, 
-    # 
+    # Subfields are passed in as comma separated list of
+    # MARC::Subfield objects,
+    #
     #   field = MARC::DataField.new('245','0','0',
     #     MARC::Subfield.new('a', 'Consilience :'),
     #     MARC::Subfield.new('b', 'the unity of knowledge '),
     #     MARC::Subfield.new('c', 'by Edward O. Wilson.'))
-    # 
+    #
     # or using a shorthand:
-    # 
+    #
     #   field = MARC::DataField.new('245','0','0',
     #     ['a', 'Consilience :'],['b','the unity of knowledge '],
     #     ['c', 'by Edward O. Wilson.'] )
 
     def initialize(tag, i1=' ', i2=' ', *subfields)
-      # if the tag is less than 3 characters long and 
+      # if the tag is less than 3 characters long and
       # the string is all numeric then we pad with zeros
       if tag.length < 3 and /^[0-9]*$/ =~ tag
         @tag = "%03d" % tag
       else
-        @tag = tag 
+        @tag = tag
       end
-      # can't allow nil to be passed in or else it'll 
+      # can't allow nil to be passed in or else it'll
       # screw us up later when we try to encode
       @indicator1 = i1 == nil ? ' ' : i1
       @indicator2 = i2 == nil ? ' ' : i2
-      
+
       @subfields = []
 
       # must use MARC::ControlField for tags < 010 or
       # those in MARC::ControlField#extra_control_fields
-      
+
       if MARC::ControlField.control_tag?(@tag)
         raise MARC::Exception.new(),
           "MARC::DataField objects can't have ControlField tag '" + @tag + "')"
@@ -72,19 +78,19 @@ module MARC
 
       # allows MARC::Subfield objects to be passed directly
       # or a shorthand of ['a','Foo'], ['b','Bar']
-      subfields.each do |subfield| 
+      subfields.each do |subfield|
         case subfield
         when MARC::Subfield
           @subfields.push(subfield)
         when Array
           if subfield.length > 2
             raise MARC::Exception.new(),
-              "arrays must only have 2 elements: " + subfield.to_s 
+              "arrays must only have 2 elements: " + subfield.to_s
           end
           @subfields.push(
             MARC::Subfield.new(subfield[0],subfield[1]))
-        else 
-          raise MARC::Exception.new(), 
+        else
+          raise MARC::Exception.new(),
             "invalid subfield type #{subfield.class}"
         end
       end
@@ -96,7 +102,7 @@ module MARC
 
     def to_s
       str = "#{tag} "
-      str += "#{indicator1}#{indicator2} " 
+      str += "#{indicator1}#{indicator2} "
       @subfields.each { |subfield| str += subfield.to_s }
       return str
     end
@@ -105,16 +111,16 @@ module MARC
     def to_marchash
       return [@tag, @indicator1, @indicator2, @subfields.map {|sf| [sf.code, sf.value]} ]
     end
-    
+
     # Turn the variable field and subfields into a hash for MARC-in-JSON
-    
+
     def to_hash
       field_hash = {@tag=>{'ind1'=>@indicator1,'ind2'=>@indicator2,'subfields'=>[]}}
       self.each do |subfield|
         field_hash[@tag]['subfields'] << {subfield.code=>subfield.value}
       end
       field_hash
-    end    
+    end
 
     # Add a subfield (MARC::Subfield) to the field
     #    field.append(MARC::Subfield.new('a','Dave Thomas'))
@@ -123,52 +129,34 @@ module MARC
       @subfields.push(subfield)
     end
 
-    
-
-    # You can iterate through the subfields in a Field:
-    #   field.each {|s| print s}
-
-    def each
-      for subfield in subfields
-        yield subfield
-      end
-    end
-
-    #def each_by_code(filter)
-    #  @subfields.each_by_code(filter)
-    #end
-
-    # You can lookup subfields with this shorthand. Note it 
+    # You can lookup subfields with this shorthand. Note it
     # will return a string and not a MARC::Subfield object.
+    #
+    # NOTE: the value of only the *first* subfield is returned
     #   subfield = field['a']
-    
+
     def [](code)
-      subfield = self.find {|s| s.code == code}
+      subfield = self.detect {|s| s.code == code}
       return subfield.value if subfield
-      return
+      return nil
     end
- 
+
 
     def codes(dedup=true)
-      codes = []
-      @subfields.each {|s| codes << s.code }
-      dedup ? codes.uniq : codes
+      codes = subfields.map(&:code)
+      codes.uniq! if dedup
+      codes
     end
 
-    # Two fields are equal if their tag, indicators and 
+    # Two fields are equal if their tag, indicators and
     # subfields are all equal.
 
     def ==(other)
-      if @tag != other.tag
-        return false 
-      elsif @indicator1 != other.indicator1
-        return false 
-      elsif @indicator2 != other.indicator2
-        return false 
-      elsif @subfields != other.subfields
-        return false
-      end
-      return true
+      tag == other.tag and
+        indicator1 == other.indicator1 and
+        indicator2 == other.indicator2 and
+        subfields.size == other.subfields.size and
+        subfields.zip(other.subfields).all?{|a| a[0] == a[1] }
     end
 
 

--- a/lib/marc/datafield.rb
+++ b/lib/marc/datafield.rb
@@ -112,6 +112,16 @@ module MARC
       return [@tag, @indicator1, @indicator2, @subfields.map {|sf| [sf.code, sf.value]} ]
     end
 
+
+    # Create a datafield from a marc-in-json style tag/datahash pair
+    def self.new_from_marc_in_hash(tag,datahash)
+      f = self.new(tag, datahash['ind1'], datahash['ind2'])
+      datahash['subfields'].each do |sf|
+        code,data = sf.first
+        f.append MARC::Subfield.new(code,data)
+      end
+      f
+    end
     # Turn the variable field and subfields into a hash for MARC-in-JSON
 
     def to_hash

--- a/lib/marc/record.rb
+++ b/lib/marc/record.rb
@@ -33,13 +33,16 @@ module MARC
     # Returns an array of fields, in the order they appear, according to their tag.
     # The tags argument can be a string (e.g. '245'), an array (['100','700','800'])
     # or a range (('600'..'699')).
-    def each_by_tag(tags)
+    def by_tag(tags)
       reindex unless @clean
       indices = @tags.values_at(*(@tags.keys & [*tags])).flatten.sort
       return [] if indices.empty?
-      self.values_at(*indices).each do |tag|
-        yield tag
-      end
+      return self.values_at(*indices)
+    end
+
+    # Iterate over the #by_tag(filter) list
+    def each_by_tag(tags)
+      by_tag(tags).each {|x| yield x }
     end
 
     # Freeze for immutability, first reindexing if needed.

--- a/lib/marc/subfield.rb
+++ b/lib/marc/subfield.rb
@@ -1,27 +1,24 @@
 module MARC
-  
-  # A class that represents an individual  subfield within a DataField. 
-  # Accessor attributes include: code (letter subfield code) and value 
-  # (the content of the subfield). Both can be empty string, but should 
-  # not be set to nil. 
+
+  # A class that represents an individual  subfield within a DataField.
+  # Accessor attributes include: code (letter subfield code) and value
+  # (the content of the subfield). Both can be empty string, but should
+  # not be set to nil.
 
   class Subfield
     attr_accessor :code, :value
 
     def initialize(code='' ,value='')
-      # can't allow code of value to be nil
+      # can't allow code or value to be nil
       # or else it'll screw us up later on
-      @code = code == nil ? '' : code
-      @value = value == nil ? '' : value
+      # nil.to_s == ''
+      @code = code.to_s
+      @value = value.to_s
     end
 
     def ==(other)
-      if @code != other.code
-        return false
-      elsif @value != other.value
-        return false
-      end
-      return true
+      @core == other.code and
+        @value == other.value
     end
 
     def to_s

--- a/lib/marc/subfield.rb
+++ b/lib/marc/subfield.rb
@@ -17,7 +17,7 @@ module MARC
     end
 
     def ==(other)
-      @core == other.code and
+      @code == other.code and
         @value == other.value
     end
 


### PR DESCRIPTION
(e.g., not the readers and writers)

I just went through the core classes and refactored them in a more modern Ruby style, pulling out a couple methods and basically just cleaning things up. The change to require minitest4 was just to get the tests to run at all under ruby 2.1.

Sorry about the whitespace, but not so sorry that I'm going to try to do it all again. You can add w=1 to the end of a github diff url to see it without the whitespace-only changes! [See this diff without the whitespace-only changes](https://github.com/ruby-marc/ruby-marc/pull/36/files?w=1)

Major types of changes:
- Use Forwardable to forward enumerators and a few other things to contained subfields, fields
- Reduce the complex if/then logic of comparator (`def ==(other)`) methods to just do the comparisons
- a couple instances of `alias_method` where that's all that was happening
- major simplification of the marc-in-json roundtrip code

The only weird thing in it is the use of `key,val = hash.first` to easily get the key/value pairs from the (single-pair) hashes in marc-in-json format. 

``` ruby
a = [ {1=>2}, {3=>4}, {5=>6}]
a.map {|x| k,v = x.first; "#{k}: #{v}"} #=> ["1: 2", "3: 4", "5: 6"]
```

Comments and criticisms welcome. 
