### PR TITLE
Record Class injection

### DIFF
--- a/lib/marc/reader.rb
+++ b/lib/marc/reader.rb
@@ -302,7 +302,7 @@ module MARC
     # Wraps the class method MARC::Reader::decode, using the encoding options of
     # the MARC::Reader instance.
     def decode(marc)
-      return MARC::Reader.decode(marc, @encoding_options)
+      return MARC::Reader.decode(marc, @encoding_options.merge(:record_class => record_class))
     end
 
     # A static method for turning raw MARC data in transission
@@ -313,7 +313,7 @@ module MARC
     #   [:forgiving]          needs more docs, true is some kind of forgiving
     #                         of certain kinds of bad MARC.
     def self.decode(marc, params={})
-      rec_class = params[:record_class] || @record_class || MARC::Record
+      rec_class = params[:record_class] || MARC::Record
 
       if params.has_key?(:encoding)
         $stderr.puts "DEPRECATION WARNING: MARC::Reader.decode :encoding option deprecated, please use :external_encoding"

--- a/lib/marc/xml_parsers.rb
+++ b/lib/marc/xml_parsers.rb
@@ -1,6 +1,6 @@
 module MARC
   # The MagicReader will try to use the best available XML Parser at the
-  # time of initialization.  
+  # time of initialization.
   # The order is currently:
   #   * Nokogiri
   #   * jrexml (JRuby only)
@@ -10,8 +10,8 @@ module MARC
   # added.  Realistically, this list should be limited to stream-based
   # parsers.  The magic should be used selectively, however.  After all,
   # one project's definition of 'best' might not apply universally.  It
-  # is arguable which is "best" on JRuby:  Nokogiri or jrexml.  
-  module MagicReader    
+  # is arguable which is "best" on JRuby:  Nokogiri or jrexml.
+  module MagicReader
     def self.extended(receiver)
       magic = MARC::XMLReader.best_available
       case magic
@@ -23,26 +23,26 @@ module MARC
       end
     end
   end
-  
+
   module GenericPullParser
     # Submodules must include
     #  self.extended()
     #  init()
     #  attributes_to_hash(attributes)
     #  each
-    
+
 
     # Returns our MARC::Record object to the #each block.
     def yield_record
-      @block.call(@record[:record])       
+      @block.call(@record[:record])
       @record[:record] = nil
-    end    
+    end
 
     def start_element_namespace name, attributes = [], prefix = nil, uri = nil, ns = {}
        attributes = attributes_to_hash(attributes)
        if uri == @ns
          case name.downcase
-         when 'record' then @record[:record] = MARC::Record.new
+         when 'record' then @record[:record] = blank_record
          when 'leader' then @current_element = :leader
          when 'controlfield'
            @current_element=:field
@@ -73,38 +73,38 @@ module MARC
         when /(control|data)field/
           @record[:record] << @record[:field]
           @record[:field] = nil
-          @current_element = nil if @current_element == :field          
+          @current_element = nil if @current_element == :field
         when 'subfield'
           @record[:field].append(@record[:subfield])
           @record[:subfield] = nil
           @current_element = nil if @current_element == :subfield
         end
       end
-    end  
+    end
   end
-  
+
 
   # NokogiriReader uses the Nokogiri SAX Parser to quickly read
   # a MARCXML document.  Because dynamically subclassing MARC::XMLReader
   # is a little ugly, we need to recreate all of the SAX event methods
-  # from Nokogiri::XML::SAX::Document here rather than subclassing.    
-  module NokogiriReader 
+  # from Nokogiri::XML::SAX::Document here rather than subclassing.
+  module NokogiriReader
     include GenericPullParser
     def self.extended(receiver)
       require 'nokogiri'
       receiver.init
     end
-    
+
     # Sets our instance variables for SAX parsing in Nokogiri and parser
     def init
       @record = {:record=>nil,:field=>nil,:subfield=>nil}
       @current_element = nil
       @ns = "http://www.loc.gov/MARC21/slim"
-      @parser = Nokogiri::XML::SAX::Parser.new(self)         
+      @parser = Nokogiri::XML::SAX::Parser.new(self)
     end
-    
+
     # Loop through the MARC records in the XML document
-    def each(&block)    
+    def each(&block)
       unless block_given?
         return self.enum_for(:each)
       else
@@ -112,7 +112,7 @@ module MARC
         @parser.parse(@handle)
       end
     end
-        
+
 
     def method_missing(methName, *args)
       sax_methods = [:xmldecl, :start_document, :end_document, :start_element,
@@ -121,8 +121,8 @@ module MARC
         raise NoMethodError.new("undefined method '#{methName} for #{self}", 'no_meth')
       end
     end
-     
-     private 
+
+     private
 
      def attributes_to_hash(attributes)
        hash = {}
@@ -130,15 +130,15 @@ module MARC
          hash[att.localname] = att.value
        end
        hash
-     end     
+     end
   end
 
 
-  
+
   # The REXMLReader is the 'default' parser, since we can at least be
   # assured that REXML is probably there.  It uses REXML's PullParser
   # to handle larger document sizes without consuming insane amounts of
-  # memory, but it's still REXML (read: slow), so it's a good idea to 
+  # memory, but it's still REXML (read: slow), so it's a good idea to
   # use an alternative parser if available.  If you don't know the best
   # parser available, you can use the MagicReader or set:
   #
@@ -150,23 +150,23 @@ module MARC
   #
   # or
   #
-  # reader = MARC::XMLReader.new(fh, :parser=>"magic") 
+  # reader = MARC::XMLReader.new(fh, :parser=>"magic")
   # (or the constant)
   #
   # which will cascade down to REXML if nothing better is found.
-  #  
+  #
   module REXMLReader
     def self.extended(receiver)
       require 'rexml/document'
       require 'rexml/parsers/pullparser'
       receiver.init
     end
-    
+
     # Sets our parser
     def init
       @parser = REXML::Parsers::PullParser.new(@handle)
     end
-    
+
     # Loop through the MARC records in the XML document
     def each
       unless block_given?
@@ -174,27 +174,27 @@ module MARC
       else
         while @parser.has_next?
           event = @parser.pull
-          # if it's the start of a record element 
+          # if it's the start of a record element
           if event.start_element? and strip_ns(event[0]) == 'record'
             yield build_record
           end
-        end    
+        end
       end
     end
-    
+
     private
     def strip_ns(str)
       return str.sub(/^.*:/, '')
     end
-    
+
     # will accept parse events until a record has been built up
     #
     def build_record
-      record = MARC::Record.new
+      record = blank_record
       data_field = nil
       control_field = nil
       subfield = nil
-      text = '' 
+      text = ''
       attrs = nil
       if Module.constants.index('Nokogiri') and @parser.is_a?(Nokogiri::XML::Reader)
         datafield = nil
@@ -225,7 +225,7 @@ module MARC
             control_field = MARC::ControlField.new(node.attribute('tag'))
             record << control_field
             cursor = control_field
-          when "datafield"  
+          when "datafield"
             record << datafield if datafield
             datafield = nil
             data_field = MARC::DataField.new(node.attribute('tag'), node.attribute('ind1'), node.attribute('ind2'))
@@ -238,10 +238,10 @@ module MARC
           when "record"
             record << datafield if datafield
             return record
-          end          
+          end
           #puts node.name
         end
-        
+
       else
         while @parser.has_next?
           event = @parser.pull
@@ -260,7 +260,7 @@ module MARC
               control_field = MARC::ControlField.new(attrs['tag'])
             when 'datafield'
               text = ''
-              data_field = MARC::DataField.new(attrs['tag'], attrs['ind1'], 
+              data_field = MARC::DataField.new(attrs['tag'], attrs['ind1'],
                 attrs['ind2'])
             when 'subfield'
               text = ''
@@ -286,11 +286,11 @@ module MARC
           end
         end
       end
-    end        
+    end
   end
-  
+
   # The JREXMLReader is really just here to set the load order for
-  # injecting the Java pull parser.  
+  # injecting the Java pull parser.
   module JREXMLReader
 
     def self.extended(receiver)
@@ -300,10 +300,10 @@ module MARC
       receiver.extend(REXMLReader)
     end
   end
-  
-  
-  
-  
+
+
+
+
   unless defined? JRUBY_VERSION
     module LibXMLReader
 
@@ -330,7 +330,7 @@ module MARC
     end # each
 
     def build_record
-      r = MARC::Record.new()
+      r = blank_record
         until (@parser.local_name == 'record' and @parser.node_type == XML::Reader::TYPE_END_ELEMENT) do
           @parser.read
           next if @parser.node_type == XML::Reader::TYPE_END_ELEMENT
@@ -382,7 +382,7 @@ end
       end
 
       # Loop through the MARC records in the XML document
-      def each(&block)  
+      def each(&block)
         unless block_given?
           return self.enum_for(:each)
         else
@@ -410,7 +410,7 @@ end
           hash[@parser.getAttributeName(i).getLocalPart] = @parser.getAttributeValue(i)
         end
         hash
-      end     
+      end
     end # end of module
-  end # end of if jruby  
+  end # end of if jruby
 end

--- a/lib/marc/xmlreader.rb
+++ b/lib/marc/xmlreader.rb
@@ -5,12 +5,12 @@ module MARC
   #
   #   reader = MARC::XMLReader.new('/Users/edsu/marc.xml')
   #
-  # or a File object, 
+  # or a File object,
   #
   #   reader = Marc::XMLReader.new(File.new('/Users/edsu/marc.xml'))
   #
   # or really any object that responds to read(n)
-  # 
+  #
   #   reader = MARC::XMLReader.new(StringIO.new(xml))
   #
   # By default, XMLReader uses REXML's pull parser, but you can swap
@@ -18,7 +18,7 @@ module MARC
   # 'best' one).  The :parser can either be one of the defined constants
   # or the constant's value.
   #
-  #   reader = MARC::XMLReader.new(fh, :parser=>'magic') 
+  #   reader = MARC::XMLReader.new(fh, :parser=>'magic')
   #
   # It is also possible to set the default parser at the class level so
   # all subsequent instances will use it instead:
@@ -28,10 +28,10 @@ module MARC
   #
   # Use:
   #   MARC::XMLReader.best_available!
-  # 
+  #
   # or
   #   MARC::XMLReader.nokogiri!
-  # 
+  #
   class XMLReader
     include Enumerable
     USE_BEST_AVAILABLE = 'magic'
@@ -39,11 +39,14 @@ module MARC
     USE_NOKOGIRI = 'nokogiri'
     USE_JREXML = 'jrexml'
     USE_JSTAX = 'jstax'
-    USE_LIBXML = 'libxml'    
+    USE_LIBXML = 'libxml'
     @@parser = USE_REXML
     attr_reader :parser
- 
+
     def initialize(file, options = {})
+
+      @record_class = options[:record_class] || MARC::Record
+
       if file.is_a?(String)
         handle = File.new(file)
       elsif file.respond_to?("read", 5)
@@ -61,11 +64,11 @@ module MARC
       case parser
       when 'magic' then extend MagicReader
       when 'rexml' then extend REXMLReader
-      when 'jrexml' then 
+      when 'jrexml' then
         raise ArgumentError, "jrexml only available under jruby" unless defined? JRUBY_VERSION
         extend JREXMLReader
-      when 'nokogiri' then extend NokogiriReader    
-      when 'jstax' then 
+      when 'nokogiri' then extend NokogiriReader
+      when 'jstax' then
         raise ArgumentError, "jstax only available under jruby" unless defined? JRUBY_VERSION
         extend JRubySTAXReader
       when 'libxml' then extend LibXMLReader
@@ -73,21 +76,26 @@ module MARC
       end
     end
 
+    # Get a blank record, for pushing data into
+    def blank_record
+      @record_class.new
+    end
+
     # Returns the currently set parser type
     def self.parser
       return @@parser
     end
-    
+
     # Returns an array of all the parsers available
     def self.parsers
       p = []
       self.constants.each do | const |
         next unless const.match("^USE_")
         p << const
-      end      
+      end
       return p
     end
-    
+
     # Sets the class parser
     def self.parser=(p)
       @@parser = choose_parser(p)
@@ -102,14 +110,14 @@ module MARC
         unless parser
           begin
             require 'nokogiri'
-            parser = USE_NOKOGIRI              
+            parser = USE_NOKOGIRI
           rescue LoadError
           end
         end
         unless parser
           begin
             # try to find the class, so we throw an error if not found
-            java.lang.Class.forName("javax.xml.stream.XMLInputFactory") 
+            java.lang.Class.forName("javax.xml.stream.XMLInputFactory")
             parser = USE_JSTAX
           rescue java.lang.ClassNotFoundException
           end
@@ -117,15 +125,15 @@ module MARC
         unless parser
           begin
             require 'jrexml'
-            parser = USE_JREXML    
-          rescue LoadError                        
+            parser = USE_JREXML
+          rescue LoadError
           end
-        end              
+        end
       else
         begin
           require 'nokogiri'
-          parser = USE_NOKOGIRI        
-        rescue LoadError          
+          parser = USE_NOKOGIRI
+        rescue LoadError
         end
         unless defined? JRUBY_VERSION
           unless parser
@@ -134,35 +142,35 @@ module MARC
               parser = USE_LIBXML
             rescue LoadError
             end
-          end        
+          end
         end
       end
       parser = USE_REXML unless parser
       parser
     end
-    
+
     # Sets the best available parser as the default
     def self.best_available!
       @@parser = self.best_available
     end
-    
+
     # Sets Nokogiri as the default parser
     def self.nokogiri!
       @@parser = USE_NOKOGIRI
     end
-    
+
     # Sets jrexml as the default parser
     def self.jrexml!
       @@parser = USE_JREXML
     end
-    
+
     # Sets REXML as the default parser
     def self.rexml!
       @@parser = USE_REXML
     end
-        
+
     protected
-    
+
     def self.choose_parser(p)
       match = false
       self.constants.each do | const |

--- a/test/tc_record_class_injection.rb
+++ b/test/tc_record_class_injection.rb
@@ -1,10 +1,15 @@
 require 'test/unit'
 require 'marc/record'
 require 'marc/reader'
+require 'marc/xmlreader'
 
 class MyRecord < MARC::Record
   def isbn
     self['020'] and self['020']['a']
+  end
+
+  def lccn
+    self['010'] and self['010']['a']
   end
 end
 
@@ -23,6 +28,19 @@ class RecordClassInjectionTest < MiniTest::Unit::TestCase
     reader = MARC::Reader.new('test/one.dat', :record_class => MyRecord)
     r = reader.first
     assert_equal("0471383147 (paper/cd-rom : alk. paper)", r.isbn)
+  end
+
+  def test_xml_injection
+    reader = MARC::XMLReader.new('test/one.xml')
+    r = reader.first
+    assert_raises(NoMethodError) do
+      r.isbn
+    end
+
+    reader = MARC::XMLReader.new('test/one.xml', :record_class => MyRecord)
+    r = reader.first
+    assert_equal("afc99990058366", r.lccn)
+
   end
 
 end

--- a/test/tc_record_class_injection.rb
+++ b/test/tc_record_class_injection.rb
@@ -1,0 +1,28 @@
+require 'test/unit'
+require 'marc/record'
+require 'marc/reader'
+
+class MyRecord < MARC::Record
+  def isbn
+    self['020'] and self['020']['a']
+  end
+end
+
+class RecordClassInjectionTest < MiniTest::Unit::TestCase
+  def test_ok
+    assert_equal(1,1, 'Yup. working')
+  end
+
+  def test_injection
+    reader = MARC::Reader.new('test/one.dat')
+    r = reader.first
+    assert_raises(NoMethodError) do
+      r.isbn
+    end
+
+    reader = MARC::Reader.new('test/one.dat', :record_class => MyRecord)
+    r = reader.first
+    assert_equal("0471383147 (paper/cd-rom : alk. paper)", r.isbn)
+  end
+
+end


### PR DESCRIPTION
This is the simplest possible implementation, in response to #33. There are a lot of things wrong with the way we do readers and writers, but I'm not sure this is the best time to tackle that (in lieu of more substantive changes for a backwards-incompatible 2.0 release or something). 

``` ruby
    reader = MARC::Reader.new('test/one.dat', :record_class => MyRecord)
    reader.first.class #=> MyRecord

```
