### PR TITLE
Remove ensure_valid_encoding dependency

### DIFF
--- a/marc.gemspec
+++ b/marc.gemspec
@@ -20,7 +20,6 @@ spec = Gem::Specification.new do |s|
   s.test_file     = 'test/ts_marc.rb'
   s.bindir        = 'bin'
 
-  s.add_dependency "ensure_valid_encoding"  
   s.add_dependency "scrub_rb", ">= 1.0.1", "< 2" # backport for ruby 2.1 String#scrub
 
   s.add_dependency "unf" # unicode normalization


### PR DESCRIPTION
The code is already not using it, as of ee69d525. Uses scrub_rb "polyfill"
for String#scrub in rubies pre-2.1 instead. But that commit neglected
to remove the ensure_valid_encoding dependency in gemspec.