### PR TITLE
Read 'streaming'

### DIFF
--- a/lib/marc/datafield.rb
+++ b/lib/marc/datafield.rb
@@ -59,8 +59,6 @@ module MARC
       # screw us up later when we try to encode
       @indicator1 = i1 == nil ? ' ' : i1
       @indicator2 = i2 == nil ? ' ' : i2
-      
-      @subfields = []
 
       # must use MARC::ControlField for tags < 010 or
       # those in MARC::ControlField#extra_control_fields
@@ -72,17 +70,16 @@ module MARC
 
       # allows MARC::Subfield objects to be passed directly
       # or a shorthand of ['a','Foo'], ['b','Bar']
-      subfields.each do |subfield| 
+      @subfields = subfields.collect do |subfield| 
         case subfield
         when MARC::Subfield
-          @subfields.push(subfield)
+          subfield
         when Array
           if subfield.length > 2
             raise MARC::Exception.new(),
               "arrays must only have 2 elements: " + subfield.to_s 
           end
-          @subfields.push(
-            MARC::Subfield.new(subfield[0],subfield[1]))
+          MARC::Subfield.new(subfield[0],subfield[1])
         else 
           raise MARC::Exception.new(), 
             "invalid subfield type #{subfield.class}"

--- a/lib/marc/reader.rb
+++ b/lib/marc/reader.rb
@@ -325,11 +325,11 @@ module MARC
       # where the field data starts
       base_address = record_leader[12..16].to_i
       num_fields = (base_address - LEADER_LENGTH) / DIRECTORY_ENTRY_LENGTH
-
+      buf5 = '     ' # buffer for transient data in parsing
       entries = Array.new(num_fields) do
-        [marc.read(3), marc.read(4).to_i, marc.read(5).to_i]
+        [marc.read(3), marc.read(4,buf5).to_i, marc.read(5,buf5).to_i]
       end
-      raise "missing field terminator after directory" unless marc.read(1).eql? END_OF_FIELD
+      raise "missing field terminator after directory" unless marc.read(1,buf5).eql? END_OF_FIELD
       # when operating in forgiving mode we just split on end of
       # field instead of using calculated byte offsets from the
       # directory
@@ -381,7 +381,7 @@ module MARC
         indicators = MARC::Reader.set_encoding( subfields.shift(), params)
         subfields = subfields.collect do |data|
           data = MARC::Reader.set_encoding( data, params )
-          MARC::Subfield.new(data[0,1],data[1..-1])
+          MARC::Subfield.new(data.slice!(0,1),data)
         end
         field = MARC::DataField.new(tag,indicators[0,1],indicators[1,1], *subfields)
 

--- a/lib/marc/reader.rb
+++ b/lib/marc/reader.rb
@@ -470,9 +470,9 @@ module MARC
   class ForgivingReader < Reader
 
     def each
-      @handle.each_line(END_OF_RECORD) do |raw|
+      until @handle.eof? do
         begin
-          record = MARC::Reader.decode(raw, @encoding_options.merge(:forgiving => true))
+          record = MARC::Reader.decode(@handle, @encoding_options.merge(:forgiving => true))
           yield record
         rescue StandardError => e
           # caught exception just keep barrelling along


### PR DESCRIPTION
changes to the MARCStream parser to avoid reading the entire record into memory, with some minor array handling optimizations