### PR TITLE
[test] XMLReader Enumerable methods should not be destructive

### DIFF
--- a/test/tc_xml.rb
+++ b/test/tc_xml.rb
@@ -175,7 +175,11 @@ class XMLTest < Test::Unit::TestCase
     iter.next # total of two records
     assert_raises(StopIteration) { iter.next }  
   end
-  
 
+  def test_xml_count
+    reader = MARC::XMLReader.new('test/batch.xml')
+    count1 = reader.count
+    count2 = reader.count
+    assert_equal(count1, count2)
+  end
 end
-

--- a/test/tc_xml.rb
+++ b/test/tc_xml.rb
@@ -182,4 +182,18 @@ class XMLTest < Test::Unit::TestCase
     count2 = reader.count
     assert_equal(count1, count2)
   end
+
+  def test_xml_each
+    reader = MARC::XMLReader.new('test/batch.xml')
+    count1 = 0
+    reader.each do |_|
+      count1 +=1
+    end
+
+    count2 = 0
+    reader.each do |_|
+      count2 +=1
+    end
+    assert_equal(count1, count2)
+  end
 end


### PR DESCRIPTION
This is currently a failing test, since as implemented `#count` is destructive.  I'm not sure where the method is being overridden, or I'd provide an actual patch.