### PR TITLE
New methods for removing fields and subfields.

### DIFF
--- a/lib/marc/datafield.rb
+++ b/lib/marc/datafield.rb
@@ -123,6 +123,23 @@ module MARC
       @subfields.push(subfield)
     end
 
+    # Remove a subfield (MARC::Subfield) from the field
+    # either by
+    #    field.remove('a')
+    # which will remove all $a, or by
+    #    field.remove(<MARC::Subfield>)
+    # which will only remove that specific subfield (same object)
+
+    def remove(subfield)
+      case subfield
+      when String
+        @subfields.delete_if { |sf| sf.code == subfield }
+      when MARC::Subfield
+        @subfields.delete_if { |sf| sf == subfield }
+      else
+        raise MARC::Exception
+      end
+    end
     
 
     # You can iterate through the subfields in a Field:

--- a/lib/marc/record.rb
+++ b/lib/marc/record.rb
@@ -133,6 +133,23 @@ module MARC
       @fields.clean = false
     end
 
+    # remove all fields or a single field from the record
+    # if argument is a string, remove all fields matching that tag,
+    # otherwise if field is a MARC::DataField, remove only that specific
+    # field.
+
+    def remove(field)
+      case field
+      when String
+        @fields.delete_if { |f| f.tag == field }
+      when MARC::DataField
+        @fields.delete_if { |f| f == field }
+      else
+        raise MARC::Exception
+      end
+      @fields.clean = false
+    end
+    
     # alias to append
 
     def <<(field)

--- a/test/tc_datafield.rb
+++ b/test/tc_datafield.rb
@@ -68,4 +68,24 @@ class TestField < Test::Unit::TestCase
         assert_equal(f['b'], 'Bar')
     end
 
+    def test_remove_subfield
+      f  = MARC::DataField.new('100', '0', '1',
+        MARC::Subfield.new('a', 'Foo'),
+        MARC::Subfield.new('a', 'Foz'),
+        MARC::Subfield.new('b', 'Bar') )
+      assert_equal('100 01 $a Foo $a Foz $b Bar ', f.to_s)
+      f.remove('a')
+      assert_equal('100 01 $b Bar ', f.to_s)
+    end
+
+    def test_remove_specific_subfield
+      f  = MARC::DataField.new('100', '0', '1',
+        MARC::Subfield.new('a', 'Foo'),
+        MARC::Subfield.new('a', 'Foz'),
+        MARC::Subfield.new('b', 'Bar') )
+      assert_equal('100 01 $a Foo $a Foz $b Bar ', f.to_s)
+      subfield = f.subfields.find { |sf| sf.code == 'a' && sf.value == 'Foz'}
+      f.remove(subfield)
+      assert_equal('100 01 $a Foo $b Bar ', f.to_s)
+    end
 end

--- a/test/tc_record.rb
+++ b/test/tc_record.rb
@@ -153,5 +153,29 @@ class TestRecord < Test::Unit::TestCase
 
     end
 
+    def test_remove_field
+      r = MARC::Record.new
+      r.fields.push MARC::DataField.new('100', '0', '1', ['a', 'Author'])
+      r.fields.push MARC::DataField.new('245', '1', '0', ['a', 'Title'])
+      r.fields.push MARC::DataField.new('500', '0', '1', ['a', 'Note 1'])
+      r.fields.push MARC::DataField.new('500', '0', '2', ['a', 'Note 2'])
+      assert_equal(r.fields('500').count, 2)
+      r.remove('500')
+      assert_equal(r.fields('500').count, 0)
+    end
 
+    def test_remove_specific_field
+      r = MARC::Record.new
+      r.fields.push MARC::DataField.new('100', '0', '1', ['a', 'Author'])
+      r.fields.push MARC::DataField.new('245', '1', '0', ['a', 'Title'])
+      r.fields.push MARC::DataField.new('500', '0', '4', ['a', 'Note 1'])
+      r.fields.push MARC::DataField.new('500', '0', '5', ['a', 'Note 2'])
+      assert_equal(r.fields('500').count, 2)
+
+      specific_field = r.fields.find { |f| f.tag == '500' && f.indicator2 == '4' }
+      r.remove(specific_field)
+
+      assert_equal(r.fields('500').count, 1)
+      assert_equal(r['500']['a'], 'Note 2')
+    end
 end


### PR DESCRIPTION
Methods added:

MARC::Record#remove(field)
If field is a String, remove all tags from the record where tag matches the string.
If field is a MARC::DataField, remove only that specific datafield (the exact same object)

MARC::DataField#remove(subfield)
If subfield is a String, remove all subfields from the field where the code matches the string
If field is a MARC::Subfield, remove only that specific subfield (the exact same object)