### PR TITLE
Skip bad XML records on imports with warning.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 1.9.3
   - 2.3.0
   - jruby-19mode
-  - jruby
+  - jruby-9.1.9.0
 before_install:
   - gem update --system
   - gem install bundler

--- a/test/bad_record.xml
+++ b/test/bad_record.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XML Spy v4.3 U (http://www.xmlspy.com) by Morgan Cundiff (Library of Congress) -->
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim
+http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
+	<marc:record>
+		<marc:leader>00925njm  22002777a 4500</marc:leader>
+		<marc:controlfield tag="DIE">5637241</marc:controlfield>
+		<marc:controlfield tag="003">DLC</marc:controlfield>
+		<marc:controlfield tag="005">19920826084036.0</marc:controlfield>
+		<marc:controlfield tag="007">sdubumennmplu</marc:controlfield>
+		<marc:controlfield tag="008">910926s1957    nyuuun              eng  </marc:controlfield>
+		<marc:datafield tag="010" ind1=" " ind2=" ">
+			<marc:subfield code="a">   91758335 </marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="028" ind1="0" ind2="0">
+			<marc:subfield code="a">1259</marc:subfield>
+			<marc:subfield code="b">Atlantic</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="040" ind1=" " ind2=" ">
+			<marc:subfield code="a">DLC</marc:subfield>
+			<marc:subfield code="c">DLC</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="050" ind1="0" ind2="0">
+			<marc:subfield code="a">Atlantic 1259</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="245" ind1="0" ind2="4">
+			<marc:subfield code="a">The Great Ray Charles</marc:subfield>
+			<marc:subfield code="h">[sound recording].</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="260" ind1=" " ind2=" ">
+			<marc:subfield code="a">New York, N.Y. :</marc:subfield>
+			<marc:subfield code="b">Atlantic,</marc:subfield>
+			<marc:subfield code="c">[1957?]</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="300" ind1=" " ind2=" ">
+			<marc:subfield code="a">1 sound disc :</marc:subfield>
+			<marc:subfield code="b">analog, 33 1/3 rpm ;</marc:subfield>
+			<marc:subfield code="c">12 in.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="511" ind1="0" ind2=" ">
+			<marc:subfield code="a">Ray Charles, piano &amp; celeste.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="505" ind1="0" ind2=" ">
+			<marc:subfield code="a">The Ray -- My melancholy baby -- Black coffee -- There's no you -- Doodlin' -- Sweet sixteen bars -- I surrender dear -- Undecided.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="500" ind1=" " ind2=" ">
+			<marc:subfield code="a">Brief record.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="650" ind1=" " ind2="0">
+			<marc:subfield code="a">Jazz</marc:subfield>
+			<marc:subfield code="y">1951-1960.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="650" ind1=" " ind2="0">
+			<marc:subfield code="a">Piano with jazz ensemble.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="700" ind1="1" ind2=" ">
+			<marc:subfield code="a">Charles, Ray,</marc:subfield>
+			<marc:subfield code="d">1930-</marc:subfield>
+			<marc:subfield code="4">prf</marc:subfield>
+		</marc:datafield>
+	</marc:record>
+	<marc:record>
+		<marc:leader>01832cmma 2200349 a 4500</marc:leader>
+		<marc:controlfield tag="001">12149120</marc:controlfield>
+		<marc:controlfield tag="005">20001005175443.0</marc:controlfield>
+		<marc:controlfield tag="007">cr |||</marc:controlfield>
+		<marc:controlfield tag="008">000407m19949999dcu    g   m        eng d</marc:controlfield>
+		<marc:datafield tag="906" ind1=" " ind2=" ">
+			<marc:subfield code="a">0</marc:subfield>
+			<marc:subfield code="b">ibc</marc:subfield>
+			<marc:subfield code="c">copycat</marc:subfield>
+			<marc:subfield code="d">1</marc:subfield>
+			<marc:subfield code="e">ncip</marc:subfield>
+			<marc:subfield code="f">20</marc:subfield>
+			<marc:subfield code="g">y-gencompf</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="925" ind1="0" ind2=" ">
+			<marc:subfield code="a">undetermined</marc:subfield>
+			<marc:subfield code="x">web preservation project (wpp)</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="955" ind1=" " ind2=" ">
+			<marc:subfield code="a">vb07 (stars done) 08-19-00 to HLCD lk00; AA3s lk29 received for subject Aug 25, 2000; to DEWEY 08-25-00; aa11 08-28-00</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="010" ind1=" " ind2=" ">
+			<marc:subfield code="a">   00530046 </marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="035" ind1=" " ind2=" ">
+			<marc:subfield code="a">(OCoLC)ocm44279786</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="040" ind1=" " ind2=" ">
+			<marc:subfield code="a">IEU</marc:subfield>
+			<marc:subfield code="c">IEU</marc:subfield>
+			<marc:subfield code="d">N@F</marc:subfield>
+			<marc:subfield code="d">DLC</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="042" ind1=" " ind2=" ">
+			<marc:subfield code="a">lccopycat</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="043" ind1=" " ind2=" ">
+			<marc:subfield code="a">n-us-dc</marc:subfield>
+			<marc:subfield code="a">n-us---</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="050" ind1="0" ind2="0">
+			<marc:subfield code="a">F204.W5</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="082" ind1="1" ind2="0">
+			<marc:subfield code="a">975.3</marc:subfield>
+			<marc:subfield code="2">13</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="245" ind1="0" ind2="4">
+			<marc:subfield code="a">The White House</marc:subfield>
+			<marc:subfield code="h">[computer file].</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="256" ind1=" " ind2=" ">
+			<marc:subfield code="a">Computer data.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="260" ind1=" " ind2=" ">
+			<marc:subfield code="a">Washington, D.C. :</marc:subfield>
+			<marc:subfield code="b">White House Web Team,</marc:subfield>
+			<marc:subfield code="c">1994-</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="538" ind1=" " ind2=" ">
+			<marc:subfield code="a">Mode of access: Internet.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="500" ind1=" " ind2=" ">
+			<marc:subfield code="a">Title from home page as viewed on Aug. 19, 2000.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="520" ind1="8" ind2=" ">
+			<marc:subfield code="a">Features the White House. Highlights the Executive Office of the President, which includes senior policy advisors and offices responsible for the President's correspondence and communications, the Office of the Vice President, and the Office of the First Lady. Posts contact information via mailing address, telephone and fax numbers, and e-mail. Contains the Interactive Citizens' Handbook with information on health, travel and tourism, education and training, and housing. Provides a tour and the history of the White House. Links to White House for Kids.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="610" ind1="2" ind2="0">
+			<marc:subfield code="a">White House (Washington, D.C.)</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="610" ind1="1" ind2="0">
+			<marc:subfield code="a">United States.</marc:subfield>
+			<marc:subfield code="b">Executive Office of the President.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="610" ind1="1" ind2="0">
+			<marc:subfield code="a">United States.</marc:subfield>
+			<marc:subfield code="b">Office of the Vice President.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="610" ind1="1" ind2="0">
+			<marc:subfield code="a">United States.</marc:subfield>
+			<marc:subfield code="b">Office of the First Lady.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="710" ind1="2" ind2=" ">
+			<marc:subfield code="a">White House Web Team.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="856" ind1="4" ind2="0">
+			<marc:subfield code="u">http://www.whitehouse.gov</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="856" ind1="4" ind2="0">
+			<marc:subfield code="u">http://lcweb.loc.gov/staff/wpp/whitehouse.html</marc:subfield>
+			<marc:subfield code="z">Web site archive</marc:subfield>
+		</marc:datafield>
+	</marc:record>
+</marc:collection>

--- a/test/tc_xml.rb
+++ b/test/tc_xml.rb
@@ -56,7 +56,7 @@ class XMLTest < Test::Unit::TestCase
       batch_test(parser)
     end    
   end
-  
+
   def batch_test(parser)
     reader = MARC::XMLReader.new('test/batch.xml', :parser=>parser)
     count = 0
@@ -65,6 +65,23 @@ class XMLTest < Test::Unit::TestCase
       assert_instance_of(MARC::Record, record)
     end
     assert_equal(count, 2)
+  end
+
+  def test_skip_bad_xml_record
+    @parsers.each do | parser |
+      puts "\nRunning skip_bad_xml_record with: #{parser}.\n"
+      batch_skip_bad_xml_record_test(parser)
+    end
+  end
+
+  def batch_skip_bad_xml_record_test(parser)
+    reader = MARC::XMLReader.new('test/bad_record.xml', :parser=>parser)
+    count = 0
+    for record in reader
+      count += 1
+      assert_instance_of(MARC::Record, record)
+    end
+    assert_equal(count, 1)
   end
   
   def test_read_string


### PR DESCRIPTION
Recently we were ingesting a very large set of marc xml records only to
have the whole import fail because the first record had a field with an
unknown value.

This change adds a new method `MARC::GenericPullParse#new_field` that is
used as a factory for creating new record fields in the xml parser. Then
when an error happens it is noted and the record is skipped instead of
breaking the entire import.

I stumbled onto this issue when working with the traject library.
I tried fixing it there, but could not figure it out without monkey
patching the marc library. So I think it makes more sense to update the
marc library.