### PR TITLE
update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - jruby-19mode
   - jruby
 before_install:
-  - gem update --system
   - gem install bundler
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: ruby
 bundler_args: --without documentation
 rvm:
   - 1.9.3
-  - 2.3.0
+  - 2.3.7
+  - 2.4.2
+  - 2.5.3
   - jruby-19mode
   - jruby
 before_install:


### PR DESCRIPTION
* Remove `  - gem update --system` in travis, which was unnecessary for tests to pass, but broke 1.9.3 for "1.9.3 is way old" reasons. 
* Add testing on most recent 2.3.x, as well as 2.4.x and 2.5.x. 