### PR TITLE
update version, fix gemspec deprecation

### DIFF
--- a/lib/marc/version.rb
+++ b/lib/marc/version.rb
@@ -1,3 +1,3 @@
 module MARC
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/marc.gemspec
+++ b/marc.gemspec
@@ -14,7 +14,6 @@ spec = Gem::Specification.new do |s|
   s.files         = Dir.glob("{lib,test}/**/*") + ["Rakefile", "README.md", "Changes", "LICENSE"]
   s.require_path  = 'lib'
   s.autorequire   = 'marc'
-  s.has_rdoc      = true
   s.required_ruby_version = '>= 1.8.6'
   s.authors       = ["Kevin Clarke", "Bill Dueber", "William Groppe", "Jonathan Rochkind", "Ross Singer", "Ed Summers"]
   s.test_file     = 'test/ts_marc.rb'


### PR DESCRIPTION
Update version to `1.0.3`
remove deprecated 'has_rdoc' from gemspec