### PR TITLE
Addressing warnings for Ruby 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.3.7
   - 2.4.2
   - 2.5.3
+  - 2.7.0
   - jruby-19mode
   - jruby
 before_install:

--- a/lib/marc/reader.rb
+++ b/lib/marc/reader.rb
@@ -4,7 +4,7 @@ require 'scrub_rb'
 # only when necessary
 
 module MARC
-  # A class for reading MARC binary (ISO 2709) files. 
+  # A class for reading MARC binary (ISO 2709) files.
   #
   # == Character Encoding
   #
@@ -12,7 +12,7 @@ module MARC
   # If illegal bytes for that character encoding are encountered in certain
   # operations, ruby will raise an exception. If a String is incorrectly
   # tagged with the wrong character encoding, that makes it fairly likely
-  # an illegal byte for the specified encoding will be encountered. 
+  # an illegal byte for the specified encoding will be encountered.
   #
   # So when reading binary MARC data with the MARC::Reader, it's important
   # that you let it know the expected encoding:
@@ -21,7 +21,7 @@ module MARC
   #
   # If you leave off 'external_encoding', it will use the ruby environment
   # Encoding.default_external, which is usually UTF-8 but may depend on your
-  # environment. 
+  # environment.
   #
   # Even if you expect your data to be (eg) UTF-8, it may include bad/illegal
   # bytes. By default MARC::Reader will leave these in the produced Strings,
@@ -29,58 +29,58 @@ module MARC
   # to catch this early, and ask MARC::Reader to raise immediately on illegal
   # bytes:
   #
-  #     MARC::Reader.new("path/to/file.mrc", :external_encoding => "UTF-8", 
+  #     MARC::Reader.new("path/to/file.mrc", :external_encoding => "UTF-8",
   #       :validate_encoding => true)
   #
   # Alternately, you can have MARC::Reader replace illegal bytes
   # with the Unicode Replacement Character, or with a string
   # of your choice (including the empty string, meaning just omit the bad bytes)
   #
-  #     MARC::Reader("path/to/file.mrc", :external_encoding => "UTF-8", 
+  #     MARC::Reader("path/to/file.mrc", :external_encoding => "UTF-8",
   #        :invalid => :replace)
-  #     MARC::Reader("path/to/file.mrc", :external_encoding => "UTF-8", 
+  #     MARC::Reader("path/to/file.mrc", :external_encoding => "UTF-8",
   #        :invalid => :replace, :replace => "")
   #
   # If you supply an :external_encoding argument, MARC::Reader will
   # always assume that encoding -- if you leave it off, MARC::Reader
   # will use the encoding tagged on any input you pass in, such
-  # as Strings or File handles. 
+  # as Strings or File handles.
   #
   #     # marc data will have same encoding as string.encoding:
   #     MARC::Reader.decode( string )
   #
   #     # Same, values will have encoding of string.encoding:
-  #     MARC::Reader.new(StringIO.new(string)) 
+  #     MARC::Reader.new(StringIO.new(string))
   #
   #     # data values will have cp866 encoding, per external_encoding of
   #     # File object passed in
   #     MARC::Reader.new(File.new("myfile.marc", "r:cp866"))
   #
   #     # explicitly tell MARC::Reader the encoding
-  #     MARC::Reader.new("myfile.marc", :external_encoding => "cp866") 
+  #     MARC::Reader.new("myfile.marc", :external_encoding => "cp866")
   #
   # === MARC-8
   #
   # The legacy MARC-8 encoding needs to be handled differently, because
-  # there is no built-in support in ruby for MARC-8. 
+  # there is no built-in support in ruby for MARC-8.
   #
   # You _can_ specify "MARC-8" as an external encoding. It will trigger
-  # trans-code to UTF-8 (NFC-normalized) in the internal ruby strings. 
+  # trans-code to UTF-8 (NFC-normalized) in the internal ruby strings.
   #
   #     MARC::Reader.new("marc8.mrc", :external_encoding => "MARC-8")
   #
   # For external_encoding "MARC-8", :validate_encoding is always true,
   # there's no way to ignore bad bytes in MARC-8 when transcoding to
-  # unicode.  However, just as with other encodings, the 
+  # unicode.  However, just as with other encodings, the
   # `:invalid => :replace` and `:replace => "string"`
-  # options can be used to replace bad bytes instead of raising. 
+  # options can be used to replace bad bytes instead of raising.
   #
   # If you want your MARC-8 to be transcoded internally to something
   # other than UTF-8, you can use the :internal_encoding option
-  # which works with any encoding in MARC::Reader. 
+  # which works with any encoding in MARC::Reader.
   #
-  #     MARC::Reader.new("marc8.mrc", 
-  #       :external_encoding => "MARC-8", 
+  #     MARC::Reader.new("marc8.mrc",
+  #       :external_encoding => "MARC-8",
   #       :internal_encoding => "UTF-16LE")
   #
   # If you want to read in MARC-8 without transcoding, leaving the
@@ -90,48 +90,48 @@ module MARC
   #
   #     MARC::Reader.new("marc8.mrc", :external_encoding => "binary")
   #
-  # Please note that MARC::Reader does _not_ currently have any facilities 
-  # for guessing encoding from MARC21 leader byte 9, that is ignored. 
+  # Please note that MARC::Reader does _not_ currently have any facilities
+  # for guessing encoding from MARC21 leader byte 9, that is ignored.
   #
   # === Complete Encoding Options
   #
   # These options can all be used on MARC::Reader.new _or_ MARC::Reader.decode
   # to specify external encoding, ask for a transcode to a different
-  # encoding on read, or validate or replace bad bytes in source. 
+  # encoding on read, or validate or replace bad bytes in source.
   #
   # [:external_encoding]
   #    What encoding to consider the MARC record's values to be in. This option
-  #    takes precedence over the File handle or String argument's encodings. 
+  #    takes precedence over the File handle or String argument's encodings.
   # [:internal_encoding]
   #    Ask MARC::Reader to transcode to this encoding in memory after reading
-  #    the file in. 
+  #    the file in.
   # [:validate_encoding]
   #    If you pass in `true`, MARC::Reader will promise to raise an Encoding::InvalidByteSequenceError
   #    if there are illegal bytes in the source for the :external_encoding. There is
   #    a performance penalty for this check. Without this option, an exception
-  #    _may_ or _may not_ be raised, and whether an exception or raised (or 
+  #    _may_ or _may not_ be raised, and whether an exception or raised (or
   #    what class the exception has) may change in future ruby-marc versions
-  #    without warning. 
+  #    without warning.
   # [:invalid]
   #    Just like String#encode, set to :replace and any bytes in source data
-  #    illegal for the source encoding will be replaced with the unicode 
+  #    illegal for the source encoding will be replaced with the unicode
   #    replacement character (when in unicode encodings), or else '?'. Overrides
   #    :validate_encoding. This can help you sanitize your input and
-  #    avoid ruby "invalid UTF-8 byte" exceptions later. 
+  #    avoid ruby "invalid UTF-8 byte" exceptions later.
   # [:replace]
   #    Just like String#encode, combine with `:invalid=>:replace`, set
   #    your own replacement string for invalid bytes. You may use the
-  #    empty string to simply eliminate invalid bytes. 
+  #    empty string to simply eliminate invalid bytes.
   #
   # === Warning on ruby File's own :internal_encoding, and unsafe transcoding from ruby
   #
-  # Be careful with using an explicit File object with the File's own 
-  # :internal_encoding set -- it can cause ruby to transcode your data 
-  # _before_ MARC::Reader gets it, changing the bytecount and making the 
+  # Be careful with using an explicit File object with the File's own
+  # :internal_encoding set -- it can cause ruby to transcode your data
+  # _before_ MARC::Reader gets it, changing the bytecount and making the
   # marc record unreadable in some cases. This
   # applies to Encoding.default_encoding too!
   #
-  #    # May in some cases result in unreadable marc and an exception 
+  #    # May in some cases result in unreadable marc and an exception
   #    MARC::Reader.new(  File.new("marc_in_cp866.mrc", "r:cp866:utf-8") )
   #
   #    # May in some cases result in unreadable marc and an exception
@@ -156,7 +156,7 @@ module MARC
   # https://jira.codehaus.org/browse/JRUBY-6637
   #
   # We recommend using the latest version of jruby, especially
-  # at least jruby 1.7.6. 
+  # at least jruby 1.7.6.
   class Reader
     include Enumerable
 
@@ -182,35 +182,35 @@ module MARC
     #
     # Also, if your data encoded with non ascii/utf-8 encoding
     # (for ex. when reading RUSMARC data) and you use ruby 1.9
-    # you can specify source data encoding with an option. 
+    # you can specify source data encoding with an option.
     #
     #   reader = MARC::Reader.new('marc.dat', :external_encoding => 'cp866')
     #
     # or, you can pass IO, opened in the corresponding encoding
     #
     #   reader = MARC::Reader.new(File.new('marc.dat', 'r:cp866'))
-    def initialize(file, options = {})      
+    def initialize(file, options = {})
       @encoding_options = {}
       # all can be nil
       [:internal_encoding, :external_encoding, :invalid, :replace, :validate_encoding].each do |key|
         @encoding_options[key] = options[key] if options.has_key?(key)
       end
-            
-      if file.is_a?(String)        
+
+      if file.is_a?(String)
         @handle = File.new(file)
       elsif file.respond_to?("read", 5)
         @handle = file
       else
         raise ArgumentError, "must pass in path or file"
       end
-      
+
       if (! @encoding_options[:external_encoding] ) && @handle.respond_to?(:external_encoding)
         # use file encoding only if we didn't already have an explicit one,
-        # explicit one takes precedence. 
+        # explicit one takes precedence.
         #
         # Note, please don't use ruby's own internal_encoding transcode
         # with binary marc data, the transcode can mess up the byte count
-        # and make it unreadable. 
+        # and make it unreadable.
         @encoding_options[:external_encoding] ||= @handle.external_encoding
       end
 
@@ -288,24 +288,24 @@ module MARC
     # First argument is a String
     # options include:
     #   [:external_encoding]  encoding of MARC record data values
-    #   [:forgiving]          needs more docs, true is some kind of forgiving 
-    #                         of certain kinds of bad MARC. 
+    #   [:forgiving]          needs more docs, true is some kind of forgiving
+    #                         of certain kinds of bad MARC.
     def self.decode(marc, params={})
       if params.has_key?(:encoding)
         $stderr.puts "DEPRECATION WARNING: MARC::Reader.decode :encoding option deprecated, please use :external_encoding"
         params[:external_encoding] = params.delete(:encoding)
       end
-      
+
       if (! params.has_key? :external_encoding ) && marc.respond_to?(:encoding)
         # If no forced external_encoding giving, respect the encoding
-        # declared on the string passed in. 
+        # declared on the string passed in.
         params[:external_encoding] = marc.encoding
       end
       # And now that we've recorded the current encoding, we force
       # to binary encoding, because we're going to be doing byte arithmetic,
-      # and want to avoid byte-vs-char confusion. 
+      # and want to avoid byte-vs-char confusion.
       marc.force_encoding("binary") if marc.respond_to?(:force_encoding)
-      
+
       record = Record.new()
       record.leader = marc[0..LEADER_LENGTH-1]
 
@@ -324,13 +324,13 @@ module MARC
       # when operating in forgiving mode we just split on end of
       # field instead of using calculated byte offsets from the
       # directory
-      if params[:forgiving]        
+      if params[:forgiving]
         marc_field_data = marc[base_address..-1]
         # It won't let us do the split on bad utf8 data, but
         # we haven't yet set the 'proper' encoding or used
         # our correction/replace options. So call it binary for now.
         marc_field_data.force_encoding("binary") if marc_field_data.respond_to?(:force_encoding)
-        
+
         all_fields = marc_field_data.split(END_OF_FIELD)
       else
         mba =  marc.bytes.to_a
@@ -366,7 +366,7 @@ module MARC
 
         # remove end of field
         field_data.delete!(END_OF_FIELD)
-        
+
         # add a control field or data field
         if MARC::ControlField.control_tag?(tag)
           field_data = MARC::Reader.set_encoding( field_data , params)
@@ -399,9 +399,9 @@ module MARC
       end
 
       return record
-    end  
+    end
 
-    # input passed in probably has 'binary' encoding. 
+    # input passed in probably has 'binary' encoding.
     # We'll set it to the proper encoding, and depending on settings, optionally
     # * check for valid encoding
     #   * raise if not valid
@@ -411,16 +411,16 @@ module MARC
     # Special case for encoding "MARC-8" -- will be transcoded to
     # UTF-8 (then further transcoded to external_encoding, if set).
     # For "MARC-8", validate_encoding is always true, there's no way to
-    # ignore bad bytes. 
+    # ignore bad bytes.
     #
     # Params options:
-    # 
-    #  * external_encoding: what encoding the input is expected to be in  
+    #
+    #  * external_encoding: what encoding the input is expected to be in
     #  * validate_encoding: if true, will raise if an invalid encoding
     #  * invalid:  if set to :replace, will replace bad bytes with replacement
-    #              chars instead of raising. 
+    #              chars instead of raising.
     #  * replace: Set replacement char for use with 'invalid', otherwise defaults
-    #             to unicode replacement char, or question mark. 
+    #             to unicode replacement char, or question mark.
     def self.set_encoding(str, params)
       if str.respond_to?(:force_encoding)
         if params[:external_encoding]
@@ -430,18 +430,18 @@ module MARC
           else
             str = str.force_encoding(params[:external_encoding])
           end
-        end     
-            
+        end
+
         # If we're transcoding anyway, pass our invalid/replace options
         # on to String#encode, which will take care of them -- or raise
-        # with illegal bytes without :replace=>:invalid. 
+        # with illegal bytes without :replace=>:invalid.
         #
         # If we're NOT transcoding, we need to use our own pure-ruby
         # implementation to do invalid byte replacements. OR to raise
         # a predicatable exception iff :validate_encoding, otherwise
         # for performance we won't check, and you may or may not
         # get an exception from inside ruby-marc, and it may change
-        # in future implementations. 
+        # in future implementations.
         if params[:internal_encoding]
           str = str.encode(params[:internal_encoding], params)
         elsif (params[:invalid] || params[:replace] || (params[:validate_encoding] == true))
@@ -452,11 +452,11 @@ module MARC
           if params[:invalid] == :replace
             str = str.scrub(params[:replace])
           end
-          
-         end          
-       end
-       return str
-    end                
+
+        end
+      end
+      return str
+    end
   end
 
 
@@ -475,11 +475,11 @@ module MARC
   #
   # **NOTE**: ForgivingReader _may_ have unpredictable results when used
   # with marc records with char encoding other than system default (usually
-  # UTF8), _especially_ if you have Encoding.default_internal set. 
+  # UTF8), _especially_ if you have Encoding.default_internal set.
   #
   # Implemented a sub-class of Reader over-riding #each, so we still
   # get DRY Reader's #initialize with proper char encoding options
-  # and handling. 
+  # and handling.
   class ForgivingReader < Reader
 
     def each
@@ -487,7 +487,7 @@ module MARC
         begin
           record = MARC::Reader.decode(raw, @encoding_options.merge(:forgiving => true))
           yield record
-        rescue StandardError => e
+        rescue StandardError
           # caught exception just keep barrelling along
           # TODO add logging
         end

--- a/lib/marc/xmlreader.rb
+++ b/lib/marc/xmlreader.rb
@@ -5,12 +5,12 @@ module MARC
   #
   #   reader = MARC::XMLReader.new('/Users/edsu/marc.xml')
   #
-  # or a File object, 
+  # or a File object,
   #
   #   reader = Marc::XMLReader.new(File.new('/Users/edsu/marc.xml'))
   #
   # or really any object that responds to read(n)
-  # 
+  #
   #   reader = MARC::XMLReader.new(StringIO.new(xml))
   #
   # By default, XMLReader uses REXML's pull parser, but you can swap
@@ -18,7 +18,7 @@ module MARC
   # 'best' one).  The :parser can either be one of the defined constants
   # or the constant's value.
   #
-  #   reader = MARC::XMLReader.new(fh, :parser=>'magic') 
+  #   reader = MARC::XMLReader.new(fh, :parser=>'magic')
   #
   # It is also possible to set the default parser at the class level so
   # all subsequent instances will use it instead:
@@ -28,10 +28,10 @@ module MARC
   #
   # Use:
   #   MARC::XMLReader.best_available!
-  # 
+  #
   # or
   #   MARC::XMLReader.nokogiri!
-  # 
+  #
   class XMLReader
     include Enumerable
     USE_BEST_AVAILABLE = 'magic'
@@ -39,10 +39,10 @@ module MARC
     USE_NOKOGIRI = 'nokogiri'
     USE_JREXML = 'jrexml'
     USE_JSTAX = 'jstax'
-    USE_LIBXML = 'libxml'    
+    USE_LIBXML = 'libxml'
     @@parser = USE_REXML
     attr_reader :parser
- 
+
     def initialize(file, options = {})
       if file.is_a?(String)
         handle = File.new(file)
@@ -61,11 +61,11 @@ module MARC
       case parser
       when 'magic' then extend MagicReader
       when 'rexml' then extend REXMLReader
-      when 'jrexml' then 
+      when 'jrexml' then
         raise ArgumentError, "jrexml only available under jruby" unless defined? JRUBY_VERSION
         extend JREXMLReader
-      when 'nokogiri' then extend NokogiriReader    
-      when 'jstax' then 
+      when 'nokogiri' then extend NokogiriReader
+      when 'jstax' then
         raise ArgumentError, "jstax only available under jruby" unless defined? JRUBY_VERSION
         extend JRubySTAXReader
       when 'libxml' then extend LibXMLReader
@@ -77,17 +77,17 @@ module MARC
     def self.parser
       return @@parser
     end
-    
+
     # Returns an array of all the parsers available
     def self.parsers
       p = []
       self.constants.each do | const |
         next unless const.match("^USE_")
         p << const
-      end      
+      end
       return p
     end
-    
+
     # Sets the class parser
     def self.parser=(p)
       @@parser = choose_parser(p)
@@ -96,20 +96,20 @@ module MARC
     # Returns the value of the best available parser
     def self.best_available
       parser = nil
-      jruby = [USE_NOKOGIRI, USE_JSTAX, USE_JREXML]
-      ruby = [USE_NOKOGIRI, USE_LIBXML]
+      # jruby = [USE_NOKOGIRI, USE_JSTAX, USE_JREXML]
+      # ruby = [USE_NOKOGIRI, USE_LIBXML]
       if defined? JRUBY_VERSION
         unless parser
           begin
             require 'nokogiri'
-            parser = USE_NOKOGIRI              
+            parser = USE_NOKOGIRI
           rescue LoadError
           end
         end
         unless parser
           begin
             # try to find the class, so we throw an error if not found
-            java.lang.Class.forName("javax.xml.stream.XMLInputFactory") 
+            java.lang.Class.forName("javax.xml.stream.XMLInputFactory")
             parser = USE_JSTAX
           rescue java.lang.ClassNotFoundException
           end
@@ -117,15 +117,15 @@ module MARC
         unless parser
           begin
             require 'jrexml'
-            parser = USE_JREXML    
-          rescue LoadError                        
+            parser = USE_JREXML
+          rescue LoadError
           end
-        end              
+        end
       else
         begin
           require 'nokogiri'
-          parser = USE_NOKOGIRI        
-        rescue LoadError          
+          parser = USE_NOKOGIRI
+        rescue LoadError
         end
         unless defined? JRUBY_VERSION
           unless parser
@@ -134,35 +134,35 @@ module MARC
               parser = USE_LIBXML
             rescue LoadError
             end
-          end        
+          end
         end
       end
       parser = USE_REXML unless parser
       parser
     end
-    
+
     # Sets the best available parser as the default
     def self.best_available!
       @@parser = self.best_available
     end
-    
+
     # Sets Nokogiri as the default parser
     def self.nokogiri!
       @@parser = USE_NOKOGIRI
     end
-    
+
     # Sets jrexml as the default parser
     def self.jrexml!
       @@parser = USE_JREXML
     end
-    
+
     # Sets REXML as the default parser
     def self.rexml!
       @@parser = USE_REXML
     end
-        
+
     protected
-    
+
     def self.choose_parser(p)
       match = false
       self.constants.each do | const |

--- a/test/marc8/tc_to_unicode.rb
+++ b/test/marc8/tc_to_unicode.rb
@@ -55,7 +55,7 @@ if "".respond_to?(:encoding)
 
           assert_equal utf8, converted, "Test data line #{i}, expected converted to match provided utf8"
         end
-      rescue EOFError => each
+      rescue EOFError
         # just means the file was over, no biggie
         assert i > 1500, "Read as many lines as we expected to, at least 1500"
       rescue Exception => e

--- a/test/tc_controlfield.rb
+++ b/test/tc_controlfield.rb
@@ -11,40 +11,39 @@ class TestField < Test::Unit::TestCase
   def test_field_as_control
     assert_raise(MARC::Exception) do
       # can't have a field with a tag < 010
-      field = MARC::DataField.new('007') 
+      MARC::DataField.new('007')
     end
   end
 
   def test_alpha_control_field
     assert_raise(MARC::Exception) do
       # can't have a field with a tag < 010
-      field = MARC::ControlField.new('DDD') 
+      MARC::ControlField.new('DDD')
     end
   end
-  
+
   def test_extra_control_field
     MARC::ControlField.control_tags << 'FMT'
     assert_nothing_raised do
-       field = MARC::ControlField.new('FMT') 
+       MARC::ControlField.new('FMT')
     end
     assert_raise(MARC::Exception) do
-      field = MARC::DataField.new('FMT') 
+      MARC::DataField.new('FMT')
     end
     MARC::ControlField.control_tags.delete('FMT')
     assert_nothing_raised do
-       field = MARC::DataField.new('FMT') 
+       MARC::DataField.new('FMT')
     end
     assert_raise(MARC::Exception) do
-      field = MARC::ControlField.new('FMT') 
+      MARC::ControlField.new('FMT')
     end
-    
+
   end
 
   def test_control_as_field
     assert_raise(MARC::Exception) do
       # can't have a control with a tag > 009
-      f = MARC::ControlField.new('245')
+      MARC::ControlField.new('245')
     end
   end
 end
-

--- a/test/tc_reader_char_encodings.rb
+++ b/test/tc_reader_char_encodings.rb
@@ -11,42 +11,42 @@ require 'stringio'
 # (becuase the func they are testing is no-op on 1.9).
 
 if "".respond_to?(:encoding)
-  
+
   class ReaderCharEncodingsTest < Test::Unit::TestCase
     ####
     # Helper methods for our tests
     #
     ####
-    
-    
+
+
     @@utf_marc_path = 'test/utf8.marc'
     # tests against record at test/utf8.marc
     def assert_utf8_right_in_utf8(record)
       assert_equal "UTF-8", record['245'].subfields.first.value.encoding.name
-            
+
       assert_equal "UTF-8", record['245'].to_s.encoding.name
-      
+
       assert_equal "UTF-8", record['245'].subfields.first.to_s.encoding.name
       assert_equal "UTF-8", record['245'].subfields.first.value.encoding.name
-      
+
       assert_equal "UTF-8", record['245']['a'].encoding.name
       assert record['245']['a'].start_with?("Photčhanānukrom")
     end
-    
-    # Test against multirecord just to be sure that works. 
+
+    # Test against multirecord just to be sure that works.
     # the multirecord file is just two concatenated copies
-    # of the single one. 
+    # of the single one.
     @@cp866_marc_path = "test/cp866_multirecord.marc"
     # assumes record in test/cp866_unimarc.marc
     # Pass in an encoding name, using ruby's canonical name!
-    # "IBM866" not "cp866". "UTF-8". 
+    # "IBM866" not "cp866". "UTF-8".
     def assert_cp866_right(record, encoding = "IBM866")
       assert_equal(encoding, record['001'].value.encoding.name)
-      assert_equal(["d09d"], record['001'].value.encode("UTF-8").unpack('H4')) # russian capital N    
+      assert_equal(["d09d"], record['001'].value.encode("UTF-8").unpack('H4')) # russian capital N
     end
 
     @@bad_marc8_path = "test/bad_eacc_encoding.marc8.marc"
-    
+
 
     def assert_all_values_valid_encoding(record, encoding_name="UTF-8")
       record.fields.each do |field|
@@ -65,62 +65,62 @@ if "".respond_to?(:encoding)
     ####
     # end helper methods
     ####
-    
-    
+
+
     def test_unicode_load
       reader = MARC::Reader.new(@@utf_marc_path)
-      
+
       record = nil
-      
+
       assert_nothing_raised { record = reader.first }
-      
+
       assert_utf8_right_in_utf8(record)
     end
-    
-    
+
+
     def test_unicode_decode_forgiving
       # two kinds of forgiving invocation, they shouldn't be different,
       # but just in case they have slightly different code paths, test em
-      # too. 
-      marc_string = File.open(@@utf_marc_path).read.force_encoding("utf-8")      
+      # too.
+      marc_string = File.open(@@utf_marc_path).read.force_encoding("utf-8")
       record = MARC::Reader.decode(marc_string, :forgiving => true)
       assert_utf8_right_in_utf8(record)
 
-      
+
       reader = MARC::ForgivingReader.new(@@utf_marc_path)
       record = reader.first
       assert_utf8_right_in_utf8(record)
     end
-    
+
     def test_unicode_forgiving_reader_passes_options
       # Make sure ForgivingReader accepts same options as MARC::Reader
       # We don't test them ALL though, just a sample.
-      # Tell it we're reading cp866, but trancode to utf8 for us. 
+      # Tell it we're reading cp866, but trancode to utf8 for us.
       reader = MARC::ForgivingReader.new(@@cp866_marc_path, :external_encoding => "cp866", :internal_encoding => "utf-8")
 
-      record = reader.first 
+      record = reader.first
 
       assert_cp866_right(record, "UTF-8")
     end
-  
+
     def test_explicit_encoding
       reader = MARC::Reader.new(@@cp866_marc_path, :external_encoding => 'cp866')
-      
+
       assert_cp866_right(reader.first, "IBM866")
     end
-    
+
     def test_bad_encoding_name_input
       reader = MARC::Reader.new(@@cp866_marc_path, :external_encoding => 'adadfadf')
       assert_raises ArgumentError do
         reader.first
       end
     end
-    
+
     def test_marc8_with_binary
-      # Marc8, if we want to keep it without transcoding, best we can do is read it in binary. 
+      # Marc8, if we want to keep it without transcoding, best we can do is read it in binary.
       reader = MARC::Reader.new('test/marc8_accented_chars.marc', :external_encoding => 'binary')
       record = reader.first
-   
+
       assert_equal "ASCII-8BIT", record['100'].subfields.first.value.encoding.name
     end
 
@@ -154,7 +154,7 @@ if "".respond_to?(:encoding)
     def test_bad_marc8_raises
       assert_raise(Encoding::InvalidByteSequenceError) do
         reader = MARC::Reader.new(@@bad_marc8_path, :external_encoding => 'MARC-8')
-        record = reader.first
+        reader.first
       end
     end
 
@@ -162,35 +162,35 @@ if "".respond_to?(:encoding)
       reader = MARC::Reader.new(@@bad_marc8_path, :external_encoding => 'MARC-8', :invalid => :replace, :replace => "[?]")
       record = reader.first
 
-      assert_all_values_valid_encoding(record)      
-      
+      assert_all_values_valid_encoding(record)
+
       assert record['880']['a'].include?("[?]"), "includes specified replacement string"
     end
 
 
     def test_load_file_opened_with_external_encoding
       reader = MARC::Reader.new(File.open(@@cp866_marc_path, 'r:cp866'))
-      
-      record = reader.first  
+
+      record = reader.first
       # Make sure it's got the encoding it's supposed to.
-      
-      assert_cp866_right(record, "IBM866")      
+
+      assert_cp866_right(record, "IBM866")
     end
-    
+
     def test_explicit_encoding_beats_file_encoding
       reader = MARC::Reader.new(File.open(@@cp866_marc_path, 'r:utf-8'), :external_encoding => "cp866")
-      
+
       record = reader.first
-      
-      assert_cp866_right(record, "IBM866")            
+
+      assert_cp866_right(record, "IBM866")
     end
-    
+
     def test_from_string_with_utf8_encoding
       marc_file = File.open(@@utf_marc_path)
-      
+
       reader = MARC::Reader.new(marc_file)
-      record = reader.first
-      
+      reader.first
+
 
 
 
@@ -200,7 +200,7 @@ if "".respond_to?(:encoding)
     # bad bytes should be handled appropriately
     def test_from_string_utf8_with_bad_byte
       marc_file = File.open('test/marc_with_bad_utf8.utf8.marc')
-      
+
       reader = MARC::Reader.new(marc_file, :invalid => :replace)
 
       record = reader.first
@@ -219,127 +219,127 @@ if "".respond_to?(:encoding)
 
       assert record['520']['a'].include?("\uFFFD"), "Value with bad byte now has Unicode Replacement Char"
     end
-    
+
     def test_from_string_with_cp866
       marc_string = File.open(@@cp866_marc_path).read.force_encoding("cp866")
-      
+
       reader = MARC::Reader.new(StringIO.new(marc_string))
       record = reader.first
-      
-      assert_cp866_right(record, "IBM866")      
+
+      assert_cp866_right(record, "IBM866")
     end
-    
+
     def test_decode_from_string_with_cp866
       marc_string = File.open(@@cp866_marc_path).read.force_encoding("cp866")
-      
+
       record = MARC::Reader.decode(marc_string)
-      
-      assert_cp866_right(record, "IBM866")      
+
+      assert_cp866_right(record, "IBM866")
     end
-    
+
     def test_with_transcode
-      reader = MARC::Reader.new(@@cp866_marc_path, 
-        :external_encoding => 'cp866', 
+      reader = MARC::Reader.new(@@cp866_marc_path,
+        :external_encoding => 'cp866',
         :internal_encoding => 'UTF-8')
-      
-      record = reader.first 
-    
-      assert_cp866_right(record, "UTF-8")      
-      
+
+      record = reader.first
+
+      assert_cp866_right(record, "UTF-8")
+
     end
-    
+
     def test_with_binary_filehandle
       # about to recommend this as a foolproof way to avoid
       # ruby transcoding behind your back in docs, let's make
-      # sure it really works. 
+      # sure it really works.
       reader = MARC::Reader.new(File.open(@@cp866_marc_path, :external_encoding => "binary", :internal_encoding => "binary"),
         :external_encoding => "IBM866")
-        
+
       record = reader.first
       assert_cp866_right(record, "IBM866")
     end
-    
+
     def test_with_bad_source_bytes
-      reader = MARC::Reader.new('test/utf8_with_bad_bytes.marc', 
+      reader = MARC::Reader.new('test/utf8_with_bad_bytes.marc',
         :external_encoding => "UTF-8",
         :validate_encoding => true)
-      
+
       assert_raise Encoding::InvalidByteSequenceError do
-        record = reader.first
+        reader.first
       end
     end
-    
+
     def test_bad_source_bytes_with_replace
-      reader = MARC::Reader.new('test/utf8_with_bad_bytes.marc', 
+      reader = MARC::Reader.new('test/utf8_with_bad_bytes.marc',
         :external_encoding => "UTF-8", :invalid => :replace)
-      
+
       record = nil
       assert_nothing_raised do
         record = reader.first
       end
-      
+
       # it should have the unicode replacement char where the bad
-      # byte was. 
-      assert_match '=> ' +  "\uFFFD" + '( <=', record['245']['a']      
+      # byte was.
+      assert_match '=> ' +  "\uFFFD" + '( <=', record['245']['a']
     end
-    
+
     def test_bad_source_bytes_with_custom_replace
-      reader = MARC::Reader.new('test/utf8_with_bad_bytes.marc', 
+      reader = MARC::Reader.new('test/utf8_with_bad_bytes.marc',
         :external_encoding => "UTF-8", :invalid => :replace, :replace => '')
-      
+
       record = reader.first
-      
-      # bad byte replaced with empty string, gone.     
+
+      # bad byte replaced with empty string, gone.
       assert_match '=> ( <=', record['245']['a']
-      
+
     end
-    
-    def test_default_internal_encoding      
+
+    def test_default_internal_encoding
       # Some people WILL be changing their Encoding.default_internal
-      # It's even recommended by wycats 
+      # It's even recommended by wycats
       # http://yehudakatz.com/2010/05/05/ruby-1-9-encodings-a-primer-and-the-solution-for-rails/
       # This will in some cases make ruby File object trans-code
       # by default. Trans-coding a serial marc binary can change the
-      # byte count and mess it up. 
+      # byte count and mess it up.
       #
       # But at present, because of the way the Reader is implemented reading
       # specific bytecounts, it _works_, although it does not _respect_
       # Encoding.default_internal. That's the best we can do right now,
-      # thsi test is important to ensure it stays at least this good. 
+      # thsi test is important to ensure it stays at least this good.
        begin
          original = Encoding.default_internal
          Encoding.default_internal = "UTF-8"
-         
+
          reader = MARC::Reader.new(File.open(@@cp866_marc_path, 'r:cp866'))
-       
+
          record = reader.first
-         
-         assert_cp866_right(record, "IBM866")                        
+
+         assert_cp866_right(record, "IBM866")
        ensure
          Encoding.default_internal = original
-       end      
+       end
     end
-    
+
     def test_default_internal_encoding_with_string_arg
       begin
-         original = Encoding.default_internal
-         Encoding.default_internal = "UTF-8"
-         
-         reader = MARC::Reader.new(@@cp866_marc_path, :external_encoding => "cp866")
-       
-         record = reader.first
-         
-         assert_cp866_right(record, "IBM866")                        
-       ensure
-         Encoding.default_internal = original
-       end    
+        original = Encoding.default_internal
+        Encoding.default_internal = "UTF-8"
+
+        reader = MARC::Reader.new(@@cp866_marc_path, :external_encoding => "cp866")
+
+        record = reader.first
+
+        assert_cp866_right(record, "IBM866")
+      ensure
+        Encoding.default_internal = original
+      end
     end
-      
+
   end
-  
-  
-  
+
+
+
 else
   require 'pathname'
-  $stderr.puts "\nTests not being run in ruby 1.9.x, skipping #{Pathname.new(__FILE__).basename}\n\n"  
+  $stderr.puts "\nTests not being run in ruby 1.9.x, skipping #{Pathname.new(__FILE__).basename}\n\n"
 end

--- a/test/tc_xml.rb
+++ b/test/tc_xml.rb
@@ -32,31 +32,31 @@ class XMLTest < Test::Unit::TestCase
   end
 
 
-  def test_xml_entities    
+  def test_xml_entities
     @parsers.each do | parser |
       puts "\nRunning test_xml_entities with: #{parser}.\n"
       xml_entities_test(parser)
     end
   end
-  
+
   def xml_entities_test(parser)
     r1 = MARC::Record.new
     r1 << MARC::DataField.new('245', '0', '0', ['a', 'foo & bar & baz'])
     xml = r1.to_xml.to_s
-    assert_match /foo &amp; bar &amp; baz/, xml
+    assert_match(/foo &amp; bar &amp; baz/, xml)
 
     reader = MARC::XMLReader.new(StringIO.new(xml), :parser=>parser)
     r2 = reader.entries[0]
-    assert_equal 'foo & bar & baz', r2['245']['a']    
+    assert_equal 'foo & bar & baz', r2['245']['a']
   end
-  
+
   def test_batch
     @parsers.each do | parser |
       puts "\nRunning test_batch with: #{parser}.\n"
       batch_test(parser)
-    end    
+    end
   end
-  
+
   def batch_test(parser)
     reader = MARC::XMLReader.new('test/batch.xml', :parser=>parser)
     count = 0
@@ -66,12 +66,12 @@ class XMLTest < Test::Unit::TestCase
     end
     assert_equal(count, 2)
   end
-  
+
   def test_read_string
     @parsers.each do | parser |
       puts "\nRunning test_read_string with: #{parser}.\n"
       read_string_test(parser)
-    end  
+    end
   end
 
   def read_string_test(parser)
@@ -79,34 +79,34 @@ class XMLTest < Test::Unit::TestCase
     reader = MARC::XMLReader.new(StringIO.new(xml), :parser=>parser)
     assert_equal 2, reader.entries.length
   end
-  
+
   def test_non_numeric_fields
     @parsers.each do | parser |
       puts "\nRunning test_non_numeric_fields with: #{parser}.\n"
       non_numeric_fields_test(parser)
     end
   end
-    
+
   def non_numeric_fields_test(parser)
     reader = MARC::XMLReader.new('test/non-numeric.xml', :parser=>parser)
-      count = 0
-      record = nil
-      reader.each do | rec |
-        count += 1 
-        record = rec
-      end
-      assert_equal(1, count)
-      assert_equal('9780061317842', record['ISB']['a'])
-      assert_equal('1', record['LOC']['9'])
+    count = 0
+    record = nil
+    reader.each do | rec |
+      count += 1
+      record = rec
     end
+    assert_equal(1, count)
+    assert_equal('9780061317842', record['ISB']['a'])
+    assert_equal('1', record['LOC']['9'])
+  end
 
   def test_read_no_leading_zero_write_leading_zero
     @parsers.each do | parser |
       puts "\nRunning test_read_no_leading_zero_write_leading_zero with: #{parser}.\n"
       read_no_leading_zero_write_leading_zero_test(parser)
-    end    
+    end
   end
-  
+
   def read_no_leading_zero_write_leading_zero_test(parser)
     reader = MARC::XMLReader.new('test/no-leading-zero.xml', :parser=>parser)
     record = reader.to_a[0]
@@ -118,7 +118,7 @@ class XMLTest < Test::Unit::TestCase
       puts "\nRunning test_leader_from_xml with: #{parser}.\n"
       leader_from_xml_test(parser)
     end
-  end    
+  end
 
   def leader_from_xml_test(parser)
     reader = MARC::XMLReader.new('test/one.xml', :parser=>parser)
@@ -128,19 +128,19 @@ class XMLTest < Test::Unit::TestCase
     record = MARC::Record.new_from_marc(record.to_marc)
     assert_equal '00734njm a2200217uu 4500', record.leader
   end
-  
+
   def test_read_write
     @parsers.each do | parser |
       puts "\nRunning test_read_write with: #{parser}.\n"
       read_write_test(parser)
     end
-  end    
+  end
 
   def read_write_test(parser)
     record1 = MARC::Record.new
     record1.leader =  '00925njm  22002777a 4500'
     record1.append MARC::ControlField.new('007', 'sdubumennmplu')
-    record1.append MARC::DataField.new('245', '0', '4', 
+    record1.append MARC::DataField.new('245', '0', '4',
       ['a', 'The Great Ray Charles'], ['h', '[sound recording].'])
 
     writer = MARC::XMLWriter.new('test/test.xml', :stylesheet => 'style.xsl')
@@ -148,8 +148,8 @@ class XMLTest < Test::Unit::TestCase
     writer.close
 
     xml = File.read('test/test.xml')
-    assert_match /<controlfield tag='007'>sdubumennmplu<\/controlfield>/, xml
-    assert_match /<\?xml-stylesheet type="text\/xsl" href="style.xsl"\?>/, xml
+    assert_match(/<controlfield tag='007'>sdubumennmplu<\/controlfield>/, xml)
+    assert_match(/<\?xml-stylesheet type="text\/xsl" href="style.xsl"\?>/, xml)
 
     reader = MARC::XMLReader.new('test/test.xml', :parser=>parser)
     record2 = reader.entries[0]
@@ -157,15 +157,15 @@ class XMLTest < Test::Unit::TestCase
 
     File.unlink('test/test.xml')
   end
-  
+
   def test_xml_enumerator
     @parsers.each do | parser |
       puts "\nRunning test_xml_enumerator with: #{parser}.\n"
       xml_enumerator_test(parser)
     end
   end
-  
-  
+
+
   def xml_enumerator_test(parser)
     # confusingly, test/batch.xml only has two records, not 10 like batch.dat
     reader = MARC::XMLReader.new('test/batch.xml', :parser=>parser)
@@ -173,9 +173,8 @@ class XMLTest < Test::Unit::TestCase
     r = iter.next
     assert_instance_of(MARC::Record, r)
     iter.next # total of two records
-    assert_raises(StopIteration) { iter.next }  
+    assert_raises(StopIteration) { iter.next }
   end
-  
+
 
 end
-


### PR DESCRIPTION
When I cloned the repository and ran the tests, I got the following
Ruby 2.7.0 warnings that happened at parse time (note there still
exists runtime warnings, which I have not addressed):

```console
./lib/marc/reader.rb:456: warning: mismatched indentations at 'end' with 'if' at 445
./lib/marc/reader.rb:457: warning: mismatched indentations at 'end' with 'if' at 425
./lib/marc/reader.rb:492: warning: assigned but unused variable - e
./lib/marc/xmlreader.rb:99: warning: assigned but unused variable - jruby
./lib/marc/xmlreader.rb:100: warning: assigned but unused variable - ruby
./lib/marc/xml_parsers.rb:61: warning: mismatched indentations at 'end' with 'def' at 45
./lib/marc/xml_parsers.rb:370: warning: mismatched indentations at 'end' with 'module' at 316
./lib/marc/xml_parsers.rb:371: warning: mismatched indentations at 'end' with 'unless' at 315
./test/marc8/tc_to_unicode.rb:59: warning: assigned but unused variable - each
./test/tc_controlfield.rb:14: warning: assigned but unused variable - field
./test/tc_controlfield.rb:21: warning: assigned but unused variable - field
./test/tc_controlfield.rb:28: warning: assigned but unused variable - field
./test/tc_controlfield.rb:31: warning: assigned but unused variable - field
./test/tc_controlfield.rb:35: warning: assigned but unused variable - field
./test/tc_controlfield.rb:38: warning: assigned but unused variable - field
./test/tc_controlfield.rb:46: warning: assigned but unused variable - f
./test/tc_reader_char_encodings.rb:157: warning: assigned but unused variable - record
./test/tc_reader_char_encodings.rb:192: warning: assigned but unused variable - record
./test/tc_reader_char_encodings.rb:268: warning: assigned but unused variable - record
./test/tc_reader_char_encodings.rb:333: warning: mismatched indentations at 'ensure' with 'begin' at 324
./test/tc_reader_char_encodings.rb:335: warning: mismatched indentations at 'end' with 'begin' at 324
./test/tc_xml.rb:46: warning: ambiguous first argument; put parentheses or a space even after `/' operator
./test/tc_xml.rb:101: warning: mismatched indentations at 'end' with 'def' at 90
./test/tc_xml.rb:151: warning: ambiguous first argument; put parentheses or a space even after `/' operator
./test/tc_xml.rb:152: warning: ambiguous first argument; put parentheses or a space even after `/' operator
```

With this commit, I have removed the parser warnings. _Note: I have
set my editor to automatically remove trailing whitespace in Ruby
code._

I have also added 2.7.0 to the Travis build. I suspect, based on the
runtime warnings, that this library will need revisiting in Ruby 3.0
land.