### PR TITLE
Move MARC field validation to a validation stage after reading the record

### DIFF
--- a/lib/marc/controlfield.rb
+++ b/lib/marc/controlfield.rb
@@ -2,7 +2,7 @@ require 'set'
 
 module MARC
 
-  # MARC records contain control fields, each of which has a 
+  # MARC records contain control fields, each of which has a
   # tag and value. Tags for control fields must be in the
   # 001-009 range or be specially added to the @@control_tags Set
 
@@ -26,7 +26,7 @@ module MARC
     # the value of the control field
     attr_accessor :value
 
-    # The constructor which must be passed a tag value and 
+    # The constructor which must be passed a tag value and
     # an optional value for the field.
 
     def initialize(tag, value = '')
@@ -44,7 +44,7 @@ module MARC
       messages = []
 
       unless MARC::ControlField.control_tag?(@tag)
-        messages << "tag must be in 001-009 or in the MARC::ControlField.control_tags set"
+        messages << "tag #{@tag.inspect} must be in 001-009 or in the MARC::ControlField.control_tags set"
       end
 
       messages

--- a/lib/marc/controlfield.rb
+++ b/lib/marc/controlfield.rb
@@ -32,9 +32,22 @@ module MARC
     def initialize(tag, value = '')
       @tag = tag
       @value = value
-      if not MARC::ControlField.control_tag?(@tag)
-        raise MARC::Exception.new(), "tag must be in 001-009 or in the MARC::ControlField.control_tags set"
+    end
+
+    # Returns true if there are no error messages associated with the field
+    def valid?
+      errors.none?
+    end
+
+    # Returns an array of validation errors
+    def errors
+      messages = []
+
+      unless MARC::ControlField.control_tag?(@tag)
+        messages << "tag must be in 001-009 or in the MARC::ControlField.control_tags set"
       end
+
+      messages
     end
 
     # Two control fields are equal if their tags and values are equal.

--- a/lib/marc/exception.rb
+++ b/lib/marc/exception.rb
@@ -6,12 +6,13 @@ module MARC
   class Exception < RuntimeError
   end
 
-  class RecordException < Exception
+  class RecordException < MARC::Exception
     attr_reader :record
 
     def initialize(record)
       @record = record
-      super(@record.errors.join(', '))
+      id = @record['001'] || '<record with no 001>'
+      super("Record #{id}: #{@record.errors.join("\n....")}")
     end
   end
 end

--- a/lib/marc/exception.rb
+++ b/lib/marc/exception.rb
@@ -6,4 +6,12 @@ module MARC
   class Exception < RuntimeError
   end
 
+  class RecordException < Exception
+    attr_reader :record
+
+    def initialize(record)
+      @record = record
+      super(@record.errors.join(', '))
+    end
+  end
 end

--- a/lib/marc/reader.rb
+++ b/lib/marc/reader.rb
@@ -398,6 +398,8 @@ module MARC
         end
       end
 
+      raise MARC::RecordException, record unless record.valid?
+
       return record
     end
 

--- a/lib/marc/record.rb
+++ b/lib/marc/record.rb
@@ -123,6 +123,16 @@ module MARC
       @leader[20..23] = '4500'
     end
 
+    # Returns true if there are no error messages associated with the record
+    def valid?
+      errors.none?
+    end
+
+    # Returns an array of validation errors for all fields in the record
+    def errors
+      @fields.flat_map(&:errors)
+    end
+
     # add a field to the record
     #   record.append(MARC::DataField.new( '100', '2', '0', ['a', 'Fred']))
 

--- a/lib/marc/xml_parsers.rb
+++ b/lib/marc/xml_parsers.rb
@@ -40,10 +40,12 @@ module MARC
     def yield_record
       if @record[:record].valid?
         @block.call(@record[:record])
+      elsif @error_handler
+        @error_handler.call(self, @record[:record], @block)
       else
         raise MARC::RecordException, @record[:record]
       end
-
+    ensure
       @record[:record] = nil
     end
 

--- a/lib/marc/xml_parsers.rb
+++ b/lib/marc/xml_parsers.rb
@@ -4,7 +4,7 @@ module MARC
   class XMLParseError < StandardError; end
 
   # The MagicReader will try to use the best available XML Parser at the
-  # time of initialization.  
+  # time of initialization.
   # The order is currently:
   #   * Nokogiri
   #   * jrexml (JRuby only)
@@ -14,7 +14,7 @@ module MARC
   # added.  Realistically, this list should be limited to stream-based
   # parsers.  The magic should be used selectively, however.  After all,
   # one project's definition of 'best' might not apply universally.  It
-  # is arguable which is "best" on JRuby:  Nokogiri or jrexml.  
+  # is arguable which is "best" on JRuby:  Nokogiri or jrexml.
   module MagicReader
     def self.extended(receiver)
       magic = MARC::XMLReader.best_available
@@ -35,9 +35,15 @@ module MARC
     #  attributes_to_hash(attributes)
     #  each
 
+
     # Returns our MARC::Record object to the #each block.
     def yield_record
-      @block.call(@record[:record])
+      if @record[:record].valid?
+        @block.call(@record[:record])
+      else
+        raise MARC::RecordException, @record[:record]
+      end
+
       @record[:record] = nil
     end
 
@@ -88,7 +94,7 @@ module MARC
   # NokogiriReader uses the Nokogiri SAX Parser to quickly read
   # a MARCXML document.  Because dynamically subclassing MARC::XMLReader
   # is a little ugly, we need to recreate all of the SAX event methods
-  # from Nokogiri::XML::SAX::Document here rather than subclassing.    
+  # from Nokogiri::XML::SAX::Document here rather than subclassing.
   module NokogiriReader
     include GenericPullParser
 
@@ -141,7 +147,7 @@ module MARC
   # The REXMLReader is the 'default' parser, since we can at least be
   # assured that REXML is probably there.  It uses REXML's PullParser
   # to handle larger document sizes without consuming insane amounts of
-  # memory, but it's still REXML (read: slow), so it's a good idea to 
+  # memory, but it's still REXML (read: slow), so it's a good idea to
   # use an alternative parser if available.  If you don't know the best
   # parser available, you can use the MagicReader or set:
   #
@@ -153,11 +159,11 @@ module MARC
   #
   # or
   #
-  # reader = MARC::XMLReader.new(fh, :parser=>"magic") 
+  # reader = MARC::XMLReader.new(fh, :parser=>"magic")
   # (or the constant)
   #
   # which will cascade down to REXML if nothing better is found.
-  #  
+  #
   module REXMLReader
     def self.extended(receiver)
       require 'rexml/document'
@@ -177,7 +183,7 @@ module MARC
       else
         while @parser.has_next?
           event = @parser.pull
-          # if it's the start of a record element 
+          # if it's the start of a record element
           if event.start_element? and strip_ns(event[0]) == 'record'
             yield build_record
           end
@@ -294,7 +300,7 @@ module MARC
   end
 
   # The JREXMLReader is really just here to set the load order for
-  # injecting the Java pull parser.  
+  # injecting the Java pull parser.
   module JREXMLReader
 
     def self.extended(receiver)
@@ -416,5 +422,5 @@ module MARC
         hash
       end
     end # end of module
-  end # end of if jruby  
+  end # end of if jruby
 end

--- a/lib/marc/xmlreader.rb
+++ b/lib/marc/xmlreader.rb
@@ -5,12 +5,12 @@ module MARC
   #
   #   reader = MARC::XMLReader.new('/Users/edsu/marc.xml')
   #
-  # or a File object, 
+  # or a File object,
   #
   #   reader = Marc::XMLReader.new(File.new('/Users/edsu/marc.xml'))
   #
   # or really any object that responds to read(n)
-  # 
+  #
   #   reader = MARC::XMLReader.new(StringIO.new(xml))
   #
   # By default, XMLReader uses REXML's pull parser, but you can swap
@@ -18,7 +18,7 @@ module MARC
   # 'best' one).  The :parser can either be one of the defined constants
   # or the constant's value.
   #
-  #   reader = MARC::XMLReader.new(fh, :parser=>'magic') 
+  #   reader = MARC::XMLReader.new(fh, :parser=>'magic')
   #
   # It is also possible to set the default parser at the class level so
   # all subsequent instances will use it instead:
@@ -28,10 +28,16 @@ module MARC
   #
   # Use:
   #   MARC::XMLReader.best_available!
-  # 
+  #
   # or
   #   MARC::XMLReader.nokogiri!
-  # 
+  #
+  # You can also pass in an error_handler option that will be called if
+  # there are any validation errors found when parsing a record.
+  #
+  #  reader = MARC::XMLReader.new(fh, error_handler: ->(reader, record, block) { ... })
+  #
+  # By default, a MARC::RecordException is raised halting all future parsing.
   class XMLReader
     include Enumerable
     USE_BEST_AVAILABLE = 'magic'
@@ -41,7 +47,7 @@ module MARC
     USE_JSTAX = 'jstax'
     USE_LIBXML = 'libxml'
     @@parser = USE_REXML
-    attr_reader :parser
+    attr_reader :parser, :error_handler
 
     def initialize(file, options = {})
       if file.is_a?(String)
@@ -71,6 +77,8 @@ module MARC
       when 'libxml' then extend LibXMLReader
       raise ArgumentError, "libxml not available under jruby" if defined? JRUBY_VERSION
       end
+
+      @error_handler = options[:error_handler]
     end
 
     # Returns the currently set parser type

--- a/test/tc_controlfield.rb
+++ b/test/tc_controlfield.rb
@@ -9,42 +9,32 @@ class TestField < Test::Unit::TestCase
   end
 
   def test_field_as_control
-    assert_raise(MARC::Exception) do
-      # can't have a field with a tag < 010
-      MARC::DataField.new('007')
-    end
+    field = MARC::DataField.new('007')
+    assert_equal(field.valid?, false)
   end
 
   def test_alpha_control_field
-    assert_raise(MARC::Exception) do
-      # can't have a field with a tag < 010
-      MARC::ControlField.new('DDD')
-    end
+    # can't have a field with a tag < 010
+    field = MARC::ControlField.new('DDD')
+    assert_equal(field.valid?, false)
   end
 
   def test_extra_control_field
     MARC::ControlField.control_tags << 'FMT'
-    assert_nothing_raised do
-      MARC::ControlField.new('FMT')
-    end
-    assert_raise(MARC::Exception) do
-      MARC::DataField.new('FMT')
-    end
+    field = MARC::ControlField.new('FMT')
+    assert_equal(field.valid?, true)
+    field = MARC::DataField.new('FMT')
+    assert_equal(field.valid?, false)
     MARC::ControlField.control_tags.delete('FMT')
-    assert_nothing_raised do
-      MARC::DataField.new('FMT')
-    end
-    assert_raise(MARC::Exception) do
-      MARC::ControlField.new('FMT')
-    end
-
+    field = MARC::DataField.new('FMT')
+    assert_equal(field.valid?, true)
+    field = MARC::ControlField.new('FMT')
+    assert_equal(field.valid?, false)
   end
 
   def test_control_as_field
-    assert_raise(MARC::Exception) do
-      # can't have a control with a tag > 009
-      MARC::ControlField.new('245')
-    end
+    # can't have a control with a tag > 009
+    f = MARC::ControlField.new('245')
+    assert_equal(f.valid?, false)
   end
 end
-


### PR DESCRIPTION
This allows potential error reporting to include information about the invalid record. It also allows (with the `:error_handler` property on MARC::XMLReader) implementors to correct or skip over bad data instead of halting all record processing.

Note that MARC::Reader does not (yet) have an `:error_handler` option because the current validations, at least, are impossible to recreate in MARC21.