### PR TITLE
Add all valid characters to the subfield code regex

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+v1.1.0 June 2021
+ - Add support for additional valid subfield codes in marcxml
+
 v1.0.2 July 2017
  - Now (correctly) throw an error if datafield string is the empty string
    (thanks to @bibliotechy)
@@ -147,4 +150,3 @@ v0.0.2  Mon Oct 17 17:42:57 CDT 2005
 
 v0.0.1  Mon Oct 10 10:29:20 CDT 2005
 - initial release
-

--- a/lib/marc/version.rb
+++ b/lib/marc/version.rb
@@ -1,3 +1,3 @@
 module MARC
-  VERSION = "1.0.4"
+  VERSION = "1.1.0"
 end

--- a/lib/marc/xmlwriter.rb
+++ b/lib/marc/xmlwriter.rb
@@ -60,7 +60,7 @@ module MARC
     # and returns a REXML::Document for the XML serialization.
 
     def self.encode(record, opts={})
-      singleChar = Regexp.new('[\da-z ]{1}')
+      singleChar = Regexp.new('[\dA-Za-z!"#$%&\'()*+,-./:;<=>?{}_^`~\[\]\\\]{1}')
       ctrlFieldTag = Regexp.new('00[1-9A-Za-z]{1}')
       
       # Right now, this writer handles input from the strict and


### PR DESCRIPTION
From https://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd; it looks like these characters were valid as-of marcxml 1.0 🤷‍♂️ 

```xml
<xsd:simpleType name="subfieldcodeDataType" id="code.st">
  <xsd:restriction base="xsd:string">
    <xsd:whiteSpace value="preserve"/>
    <xsd:pattern value="[\dA-Za-z!"#$%&'()*+,-./:;<=>?{}_^`~\[\]\\]{1}"/>
    <!--  "A-Z" added after "\d" May 21, 2009  -->
  </xsd:restriction>
</xsd:simpleType>
```