### PR TITLE
MARC indicators use a different set of validity requirements than subfield codes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+v1.1.1 June 2021
+- Fix a regression when normalizing indicator values when serializing marcxml
+
 v1.1.0 June 2021
  - Add support for additional valid subfield codes in marcxml
 

--- a/lib/marc/version.rb
+++ b/lib/marc/version.rb
@@ -1,3 +1,3 @@
 module MARC
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/lib/marc/xmlwriter.rb
+++ b/lib/marc/xmlwriter.rb
@@ -60,7 +60,8 @@ module MARC
     # and returns a REXML::Document for the XML serialization.
 
     def self.encode(record, opts={})
-      singleChar = Regexp.new('[\dA-Za-z!"#$%&\'()*+,-./:;<=>?{}_^`~\[\]\\\]{1}')
+      singleChar = Regexp.new('[\da-z ]{1}')
+      subfieldChar = Regexp.new('[\dA-Za-z!"#$%&\'()*+,-./:;<=>?{}_^`~\[\]\\\]{1}')
       ctrlFieldTag = Regexp.new('00[1-9A-Za-z]{1}')
       
       # Right now, this writer handles input from the strict and
@@ -122,7 +123,7 @@ module MARC
             
             # If marc is leniently parsed, we may have some dirty data; using
             # the blank subfield code should help us locate these later to fix
-            if (subfield.code.match(singleChar) == nil)
+            if (subfield.code.match(subfieldChar) == nil)
               subfield.code = ' '
             end
             

--- a/test/tc_xml.rb
+++ b/test/tc_xml.rb
@@ -140,11 +140,16 @@ class XMLTest < Test::Unit::TestCase
     record1 = MARC::Record.new
     record1.leader =  '00925njm  22002777a 4500'
     record1.append MARC::ControlField.new('007', 'sdubumennmplu')
-    record1.append MARC::DataField.new('245', '0', '4', 
+    record1.append MARC::DataField.new('245', '0', '4',
       ['a', 'The Great Ray Charles'], ['h', '[sound recording].'])
+    record1.append MARC::DataField.new('998', ' ', ' ',
+      ['^', 'Valid local subfield'])
+
+    # MARC::XMLWriter mutates records
+    dup_record = MARC::Record.new_from_hash(record1.to_hash)
 
     writer = MARC::XMLWriter.new('test/test.xml', :stylesheet => 'style.xsl')
-    writer.write(record1)
+    writer.write(dup_record)
     writer.close
 
     xml = File.read('test/test.xml')


### PR DESCRIPTION
This fixes a regression introduced in #71, and masked in the test suite because the XMLWriter mutates the records provided so any later comparison is tainted.