### PR TITLE
Use relative references instead of absolute references

### DIFF
--- a/lib/marc.rb
+++ b/lib/marc.rb
@@ -1,7 +1,7 @@
 #marc is a ruby library for reading and writing MAchine Readable Cataloging
 #(MARC). More information about MARC can be found at <http://www.loc.gov/marc>.
 #
-#USAGE 
+#USAGE
 #
 #    require 'marc'
 #
@@ -11,7 +11,7 @@
 #      puts record['245']['a']
 #    end
 #
-#    # creating a record 
+#    # creating a record
 #    record = MARC::Record.new()
 #    record.add_field(MARC::DataField.new('100', '0',  ' ', ['a', 'John Doe']))
 #

--- a/lib/marc/constants.rb
+++ b/lib/marc/constants.rb
@@ -7,7 +7,7 @@ module MARC
   END_OF_FIELD = 0x1E.chr
   END_OF_RECORD = 0x1D.chr
 
-  # constants used in XML reading/writing 
+  # constants used in XML reading/writing
   MARC_NS = "http://www.loc.gov/MARC21/slim"
   MARC_XSD = "http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"
 

--- a/lib/marc/controlfield.rb
+++ b/lib/marc/controlfield.rb
@@ -43,7 +43,7 @@ module MARC
     def errors
       messages = []
 
-      unless MARC::ControlField.control_tag?(@tag)
+      unless ControlField.control_tag?(@tag)
         messages << "tag #{@tag.inspect} must be in 001-009 or in the MARC::ControlField.control_tags set"
       end
 

--- a/lib/marc/datafield.rb
+++ b/lib/marc/datafield.rb
@@ -65,17 +65,17 @@ module MARC
       # or a shorthand of ['a','Foo'], ['b','Bar']
       subfields.each do |subfield|
         case subfield
-        when MARC::Subfield
+        when Subfield
           @subfields.push(subfield)
         when Array
           if subfield.length > 2
-            raise MARC::Exception.new(),
+            raise Exception.new(),
                   "arrays must only have 2 elements: " + subfield.to_s
           end
           @subfields.push(
-            MARC::Subfield.new(subfield[0], subfield[1]))
+            Subfield.new(subfield[0], subfield[1]))
         else
-          raise MARC::Exception.new(),
+          raise Exception.new(),
                 "invalid subfield type #{subfield.class}"
         end
       end
@@ -93,7 +93,7 @@ module MARC
       # must use MARC::ControlField for tags < 010 or
       # those in MARC::ControlField#extra_control_fields
 
-      if MARC::ControlField.control_tag?(@tag)
+      if ControlField.control_tag?(@tag)
         messages << "MARC::DataField objects can't have ControlField tag '" + @tag + "'"
       end
 

--- a/lib/marc/exception.rb
+++ b/lib/marc/exception.rb
@@ -6,7 +6,7 @@ module MARC
   class Exception < RuntimeError
   end
 
-  class RecordException < MARC::Exception
+  class RecordException < Exception
     attr_reader :record
 
     def initialize(record)

--- a/lib/marc/marc8/map_to_unicode.rb
+++ b/lib/marc/marc8/map_to_unicode.rb
@@ -1,7 +1,7 @@
 module MARC
   module Marc8
 
-    # Data to map from marc8 bytes to unicode codepoints. 
+    # Data to map from marc8 bytes to unicode codepoints.
     #
     # Ported from pymarc python to ruby using some regexps and such. Original pymarc:
     #

--- a/lib/marc/marc8/to_unicode.rb
+++ b/lib/marc/marc8/to_unicode.rb
@@ -27,7 +27,7 @@ module MARC
       G0_SET = ['(', ',', '$']
       G1_SET = [')', '-', '$']
 
-      CODESETS = MARC::Marc8::MapToUnicode::CODESETS
+      CODESETS = Marc8::MapToUnicode::CODESETS
 
       # These are state flags, MARC8 requires you to keep
       # track of 'current char sets' or something like that, which

--- a/lib/marc/reader.rb
+++ b/lib/marc/reader.rb
@@ -4,7 +4,7 @@ require 'scrub_rb'
 # only when necessary
 
 module MARC
-  # A class for reading MARC binary (ISO 2709) files. 
+  # A class for reading MARC binary (ISO 2709) files.
   #
   # == Character Encoding
   #
@@ -12,7 +12,7 @@ module MARC
   # If illegal bytes for that character encoding are encountered in certain
   # operations, ruby will raise an exception. If a String is incorrectly
   # tagged with the wrong character encoding, that makes it fairly likely
-  # an illegal byte for the specified encoding will be encountered. 
+  # an illegal byte for the specified encoding will be encountered.
   #
   # So when reading binary MARC data with the MARC::Reader, it's important
   # that you let it know the expected encoding:
@@ -21,7 +21,7 @@ module MARC
   #
   # If you leave off 'external_encoding', it will use the ruby environment
   # Encoding.default_external, which is usually UTF-8 but may depend on your
-  # environment. 
+  # environment.
   #
   # Even if you expect your data to be (eg) UTF-8, it may include bad/illegal
   # bytes. By default MARC::Reader will leave these in the produced Strings,
@@ -29,58 +29,58 @@ module MARC
   # to catch this early, and ask MARC::Reader to raise immediately on illegal
   # bytes:
   #
-  #     MARC::Reader.new("path/to/file.mrc", :external_encoding => "UTF-8", 
+  #     MARC::Reader.new("path/to/file.mrc", :external_encoding => "UTF-8",
   #       :validate_encoding => true)
   #
   # Alternately, you can have MARC::Reader replace illegal bytes
   # with the Unicode Replacement Character, or with a string
   # of your choice (including the empty string, meaning just omit the bad bytes)
   #
-  #     MARC::Reader("path/to/file.mrc", :external_encoding => "UTF-8", 
+  #     MARC::Reader("path/to/file.mrc", :external_encoding => "UTF-8",
   #        :invalid => :replace)
-  #     MARC::Reader("path/to/file.mrc", :external_encoding => "UTF-8", 
+  #     MARC::Reader("path/to/file.mrc", :external_encoding => "UTF-8",
   #        :invalid => :replace, :replace => "")
   #
   # If you supply an :external_encoding argument, MARC::Reader will
   # always assume that encoding -- if you leave it off, MARC::Reader
   # will use the encoding tagged on any input you pass in, such
-  # as Strings or File handles. 
+  # as Strings or File handles.
   #
   #     # marc data will have same encoding as string.encoding:
   #     MARC::Reader.decode( string )
   #
   #     # Same, values will have encoding of string.encoding:
-  #     MARC::Reader.new(StringIO.new(string)) 
+  #     MARC::Reader.new(StringIO.new(string))
   #
   #     # data values will have cp866 encoding, per external_encoding of
   #     # File object passed in
   #     MARC::Reader.new(File.new("myfile.marc", "r:cp866"))
   #
   #     # explicitly tell MARC::Reader the encoding
-  #     MARC::Reader.new("myfile.marc", :external_encoding => "cp866") 
+  #     MARC::Reader.new("myfile.marc", :external_encoding => "cp866")
   #
   # === MARC-8
   #
   # The legacy MARC-8 encoding needs to be handled differently, because
-  # there is no built-in support in ruby for MARC-8. 
+  # there is no built-in support in ruby for MARC-8.
   #
   # You _can_ specify "MARC-8" as an external encoding. It will trigger
-  # trans-code to UTF-8 (NFC-normalized) in the internal ruby strings. 
+  # trans-code to UTF-8 (NFC-normalized) in the internal ruby strings.
   #
   #     MARC::Reader.new("marc8.mrc", :external_encoding => "MARC-8")
   #
   # For external_encoding "MARC-8", :validate_encoding is always true,
   # there's no way to ignore bad bytes in MARC-8 when transcoding to
-  # unicode.  However, just as with other encodings, the 
+  # unicode.  However, just as with other encodings, the
   # `:invalid => :replace` and `:replace => "string"`
-  # options can be used to replace bad bytes instead of raising. 
+  # options can be used to replace bad bytes instead of raising.
   #
   # If you want your MARC-8 to be transcoded internally to something
   # other than UTF-8, you can use the :internal_encoding option
-  # which works with any encoding in MARC::Reader. 
+  # which works with any encoding in MARC::Reader.
   #
-  #     MARC::Reader.new("marc8.mrc", 
-  #       :external_encoding => "MARC-8", 
+  #     MARC::Reader.new("marc8.mrc",
+  #       :external_encoding => "MARC-8",
   #       :internal_encoding => "UTF-16LE")
   #
   # If you want to read in MARC-8 without transcoding, leaving the
@@ -90,48 +90,48 @@ module MARC
   #
   #     MARC::Reader.new("marc8.mrc", :external_encoding => "binary")
   #
-  # Please note that MARC::Reader does _not_ currently have any facilities 
-  # for guessing encoding from MARC21 leader byte 9, that is ignored. 
+  # Please note that MARC::Reader does _not_ currently have any facilities
+  # for guessing encoding from MARC21 leader byte 9, that is ignored.
   #
   # === Complete Encoding Options
   #
   # These options can all be used on MARC::Reader.new _or_ MARC::Reader.decode
   # to specify external encoding, ask for a transcode to a different
-  # encoding on read, or validate or replace bad bytes in source. 
+  # encoding on read, or validate or replace bad bytes in source.
   #
   # [:external_encoding]
   #    What encoding to consider the MARC record's values to be in. This option
-  #    takes precedence over the File handle or String argument's encodings. 
+  #    takes precedence over the File handle or String argument's encodings.
   # [:internal_encoding]
   #    Ask MARC::Reader to transcode to this encoding in memory after reading
-  #    the file in. 
+  #    the file in.
   # [:validate_encoding]
   #    If you pass in `true`, MARC::Reader will promise to raise an Encoding::InvalidByteSequenceError
   #    if there are illegal bytes in the source for the :external_encoding. There is
   #    a performance penalty for this check. Without this option, an exception
-  #    _may_ or _may not_ be raised, and whether an exception or raised (or 
+  #    _may_ or _may not_ be raised, and whether an exception or raised (or
   #    what class the exception has) may change in future ruby-marc versions
-  #    without warning. 
+  #    without warning.
   # [:invalid]
   #    Just like String#encode, set to :replace and any bytes in source data
-  #    illegal for the source encoding will be replaced with the unicode 
+  #    illegal for the source encoding will be replaced with the unicode
   #    replacement character (when in unicode encodings), or else '?'. Overrides
   #    :validate_encoding. This can help you sanitize your input and
-  #    avoid ruby "invalid UTF-8 byte" exceptions later. 
+  #    avoid ruby "invalid UTF-8 byte" exceptions later.
   # [:replace]
   #    Just like String#encode, combine with `:invalid=>:replace`, set
   #    your own replacement string for invalid bytes. You may use the
-  #    empty string to simply eliminate invalid bytes. 
+  #    empty string to simply eliminate invalid bytes.
   #
   # === Warning on ruby File's own :internal_encoding, and unsafe transcoding from ruby
   #
-  # Be careful with using an explicit File object with the File's own 
-  # :internal_encoding set -- it can cause ruby to transcode your data 
-  # _before_ MARC::Reader gets it, changing the bytecount and making the 
+  # Be careful with using an explicit File object with the File's own
+  # :internal_encoding set -- it can cause ruby to transcode your data
+  # _before_ MARC::Reader gets it, changing the bytecount and making the
   # marc record unreadable in some cases. This
   # applies to Encoding.default_encoding too!
   #
-  #    # May in some cases result in unreadable marc and an exception 
+  #    # May in some cases result in unreadable marc and an exception
   #    MARC::Reader.new(  File.new("marc_in_cp866.mrc", "r:cp866:utf-8") )
   #
   #    # May in some cases result in unreadable marc and an exception
@@ -156,7 +156,7 @@ module MARC
   # https://jira.codehaus.org/browse/JRUBY-6637
   #
   # We recommend using the latest version of jruby, especially
-  # at least jruby 1.7.6. 
+  # at least jruby 1.7.6.
   class Reader
     include Enumerable
 
@@ -182,7 +182,7 @@ module MARC
     #
     # Also, if your data encoded with non ascii/utf-8 encoding
     # (for ex. when reading RUSMARC data) and you use ruby 1.9
-    # you can specify source data encoding with an option. 
+    # you can specify source data encoding with an option.
     #
     #   reader = MARC::Reader.new('marc.dat', :external_encoding => 'cp866')
     #
@@ -206,17 +206,17 @@ module MARC
 
       if (!@encoding_options[:external_encoding]) && @handle.respond_to?(:external_encoding)
         # use file encoding only if we didn't already have an explicit one,
-        # explicit one takes precedence. 
+        # explicit one takes precedence.
         #
         # Note, please don't use ruby's own internal_encoding transcode
         # with binary marc data, the transcode can mess up the byte count
-        # and make it unreadable. 
+        # and make it unreadable.
         @encoding_options[:external_encoding] ||= @handle.external_encoding
       end
 
       # Only pull in the MARC8 translation if we need it, since it's really big
       if @encoding_options[:external_encoding] == "MARC-8"
-        require 'marc/marc8/to_unicode' unless defined? MARC::Marc8::ToUnicode
+        require 'marc/marc8/to_unicode' unless defined? Marc8::ToUnicode
       end
 
     end
@@ -264,7 +264,7 @@ module MARC
           # make sure the record length looks like an integer
           rec_length_i = rec_length_s.to_i
           if rec_length_i == 0
-            raise MARC::Exception.new("invalid record length: #{rec_length_s}")
+            raise Exception.new("invalid record length: #{rec_length_s}")
           end
 
           # get the raw MARC21 for a record back from the file
@@ -280,7 +280,7 @@ module MARC
     # Wraps the class method MARC::Reader::decode, using the encoding options of
     # the MARC::Reader instance.
     def decode(marc)
-      return MARC::Reader.decode(marc, @encoding_options)
+      return Reader.decode(marc, @encoding_options)
     end
 
     # A static method for turning raw MARC data in transission
@@ -288,8 +288,8 @@ module MARC
     # First argument is a String
     # options include:
     #   [:external_encoding]  encoding of MARC record data values
-    #   [:forgiving]          needs more docs, true is some kind of forgiving 
-    #                         of certain kinds of bad MARC. 
+    #   [:forgiving]          needs more docs, true is some kind of forgiving
+    #                         of certain kinds of bad MARC.
     def self.decode(marc, params = {})
       if params.has_key?(:encoding)
         $stderr.puts "DEPRECATION WARNING: MARC::Reader.decode :encoding option deprecated, please use :external_encoding"
@@ -298,12 +298,12 @@ module MARC
 
       if (!params.has_key? :external_encoding) && marc.respond_to?(:encoding)
         # If no forced external_encoding giving, respect the encoding
-        # declared on the string passed in. 
+        # declared on the string passed in.
         params[:external_encoding] = marc.encoding
       end
       # And now that we've recorded the current encoding, we force
       # to binary encoding, because we're going to be doing byte arithmetic,
-      # and want to avoid byte-vs-char confusion. 
+      # and want to avoid byte-vs-char confusion.
       marc.force_encoding("binary") if marc.respond_to?(:force_encoding)
 
       record = Record.new()
@@ -315,7 +315,7 @@ module MARC
       # get the byte offsets from the record directory
       directory = marc[LEADER_LENGTH..base_address - 1]
 
-      raise MARC::Exception.new("invalid directory in record") if directory == nil
+      raise Exception.new("invalid directory in record") if directory == nil
 
       # the number of fields in the record corresponds to
       # how many directory entries there are
@@ -368,11 +368,11 @@ module MARC
         field_data.delete!(END_OF_FIELD)
 
         # add a control field or data field
-        if MARC::ControlField.control_tag?(tag)
-          field_data = MARC::Reader.set_encoding(field_data, params)
-          record.append(MARC::ControlField.new(tag, field_data))
+        if ControlField.control_tag?(tag)
+          field_data = Reader.set_encoding(field_data, params)
+          record.append(ControlField.new(tag, field_data))
         else
-          field = MARC::DataField.new(tag)
+          field = DataField.new(tag)
 
           # get all subfields
           subfields = field_data.split(SUBFIELD_INDICATOR)
@@ -382,14 +382,14 @@ module MARC
           next if subfields.length() < 2
 
           # get indicators
-          indicators = MARC::Reader.set_encoding(subfields.shift(), params)
+          indicators = Reader.set_encoding(subfields.shift(), params)
           field.indicator1 = indicators[0, 1]
           field.indicator2 = indicators[1, 1]
 
           # add each subfield to the field
           subfields.each() do |data|
-            data = MARC::Reader.set_encoding(data, params)
-            subfield = MARC::Subfield.new(data[0, 1], data[1..-1])
+            data = Reader.set_encoding(data, params)
+            subfield = Subfield.new(data[0, 1], data[1..-1])
             field.append(subfield)
           end
 
@@ -398,12 +398,12 @@ module MARC
         end
       end
 
-      raise MARC::RecordException, record unless record.valid?
+      raise RecordException, record unless record.valid?
 
       return record
     end
 
-    # input passed in probably has 'binary' encoding. 
+    # input passed in probably has 'binary' encoding.
     # We'll set it to the proper encoding, and depending on settings, optionally
     # * check for valid encoding
     #   * raise if not valid
@@ -413,22 +413,22 @@ module MARC
     # Special case for encoding "MARC-8" -- will be transcoded to
     # UTF-8 (then further transcoded to external_encoding, if set).
     # For "MARC-8", validate_encoding is always true, there's no way to
-    # ignore bad bytes. 
+    # ignore bad bytes.
     #
     # Params options:
-    # 
-    #  * external_encoding: what encoding the input is expected to be in  
+    #
+    #  * external_encoding: what encoding the input is expected to be in
     #  * validate_encoding: if true, will raise if an invalid encoding
     #  * invalid:  if set to :replace, will replace bad bytes with replacement
-    #              chars instead of raising. 
+    #              chars instead of raising.
     #  * replace: Set replacement char for use with 'invalid', otherwise defaults
-    #             to unicode replacement char, or question mark. 
+    #             to unicode replacement char, or question mark.
     def self.set_encoding(str, params)
       if str.respond_to?(:force_encoding)
         if params[:external_encoding]
           if params[:external_encoding] == "MARC-8"
             transcode_params = [:invalid, :replace].each_with_object({}) { |k, hash| hash[k] = params[k] if params.has_key?(k) }
-            str = MARC::Marc8::ToUnicode.new.transcode(str, transcode_params)
+            str = Marc8::ToUnicode.new.transcode(str, transcode_params)
           else
             str = str.force_encoding(params[:external_encoding])
           end
@@ -436,14 +436,14 @@ module MARC
 
         # If we're transcoding anyway, pass our invalid/replace options
         # on to String#encode, which will take care of them -- or raise
-        # with illegal bytes without :replace=>:invalid. 
+        # with illegal bytes without :replace=>:invalid.
         #
         # If we're NOT transcoding, we need to use our own pure-ruby
         # implementation to do invalid byte replacements. OR to raise
         # a predicatable exception iff :validate_encoding, otherwise
         # for performance we won't check, and you may or may not
         # get an exception from inside ruby-marc, and it may change
-        # in future implementations. 
+        # in future implementations.
         if params[:internal_encoding]
           if RUBY_VERSION >= '3.0'
             str = str.encode(params[:internal_encoding], **params)
@@ -478,17 +478,17 @@ module MARC
   #
   # **NOTE**: ForgivingReader _may_ have unpredictable results when used
   # with marc records with char encoding other than system default (usually
-  # UTF8), _especially_ if you have Encoding.default_internal set. 
+  # UTF8), _especially_ if you have Encoding.default_internal set.
   #
   # Implemented a sub-class of Reader over-riding #each, so we still
   # get DRY Reader's #initialize with proper char encoding options
-  # and handling. 
+  # and handling.
   class ForgivingReader < Reader
 
     def each
       @handle.each_line(END_OF_RECORD) do |raw|
         begin
-          record = MARC::Reader.decode(raw, @encoding_options.merge(:forgiving => true))
+          record = Reader.decode(raw, @encoding_options.merge(:forgiving => true))
           yield record
         rescue StandardError
           # caught exception just keep barrelling along

--- a/lib/marc/record.rb
+++ b/lib/marc/record.rb
@@ -222,7 +222,7 @@ module MARC
     #  record = MARC::Record.new_from_marc(marc21, :forgiving => true)
 
     def self.new_from_marc(raw, params = {})
-      return MARC::Reader.decode(raw, params)
+      return Reader.decode(raw, params)
     end
 
     # Returns a record in MARC21 transmission format (ANSI Z39.2).
@@ -231,7 +231,7 @@ module MARC
     #   marc = record.to_marc()
 
     def to_marc
-      return MARC::Writer.encode(self)
+      return Writer.encode(self)
     end
 
     # Handy method for returning the MARCXML serialization for a
@@ -241,7 +241,7 @@ module MARC
     #   xml_doc = record.to_xml()
 
     def to_xml
-      return MARC::XMLWriter.encode(self, :include_namespace => true)
+      return XMLWriter.encode(self, :include_namespace => true)
     end
 
     # Handy method for returning a hash mapping this records values
@@ -251,7 +251,7 @@ module MARC
     #   print dc['title']
 
     def to_dublin_core
-      return MARC::DublinCore.map(self)
+      return DublinCore.map(self)
     end
 
     # Return a marc-hash version of the record
@@ -276,8 +276,8 @@ module MARC
       r.leader = mh['leader']
       mh['fields'].each do |f|
         if (f.length == 2)
-          r << MARC::ControlField.new(f[0], f[1])
-        elsif r << MARC::DataField.new(f[0], f[1], f[2], *f[3])
+          r << ControlField.new(f[0], f[1])
+        elsif r << DataField.new(f[0], f[1], f[2], *f[3])
         end
       end
       return r
@@ -299,15 +299,15 @@ module MARC
         h['fields'].each do |position|
           position.each_pair do |tag, field|
             if field.is_a?(Hash)
-              f = MARC::DataField.new(tag, field['ind1'], field['ind2'])
+              f = DataField.new(tag, field['ind1'], field['ind2'])
               field['subfields'].each do |pos|
                 pos.each_pair do |code, value|
-                  f.append MARC::Subfield.new(code, value)
+                  f.append Subfield.new(code, value)
                 end
               end
               r << f
             else
-              r << MARC::ControlField.new(tag, field)
+              r << ControlField.new(tag, field)
             end
           end
         end

--- a/lib/marc/subfield.rb
+++ b/lib/marc/subfield.rb
@@ -1,9 +1,9 @@
 module MARC
 
-  # A class that represents an individual  subfield within a DataField. 
-  # Accessor attributes include: code (letter subfield code) and value 
-  # (the content of the subfield). Both can be empty string, but should 
-  # not be set to nil. 
+  # A class that represents an individual  subfield within a DataField.
+  # Accessor attributes include: code (letter subfield code) and value
+  # (the content of the subfield). Both can be empty string, but should
+  # not be set to nil.
 
   class Subfield
     attr_accessor :code, :value

--- a/lib/marc/writer.rb
+++ b/lib/marc/writer.rb
@@ -43,7 +43,7 @@ module MARC
     # write a record to the file or handle
 
     def write(record)
-      @fh.write(MARC::Writer.encode(record, self.allow_oversized))
+      @fh.write(Writer.encode(record, self.allow_oversized))
     end
 
     # close underlying filehandle
@@ -56,7 +56,7 @@ module MARC
     # and returns the record encoded as MARC21 in transmission format
     #
     # Second arg allow_oversized, default false, set to true
-    # to raise on MARC record that can't fit into ISO 2709. 
+    # to raise on MARC record that can't fit into ISO 2709.
     def self.encode(record, allow_oversized = false)
       directory = ''
       fields = ''
@@ -65,13 +65,13 @@ module MARC
 
         # encode the field
         field_data = ''
-        if field.class == MARC::DataField
+        if field.class == DataField
           warn("Warn:  Missing indicator") unless field.indicator1 && field.indicator2
           field_data = (field.indicator1 || " ") + (field.indicator2 || " ")
           for s in field.subfields
             field_data += SUBFIELD_INDICATOR + s.code + s.value
           end
-        elsif field.class == MARC::ControlField
+        elsif field.class == ControlField
           field_data = field.value
         end
         field_data += END_OF_FIELD
@@ -126,7 +126,7 @@ module MARC
         if allow_oversized
           formatted = sprintf("%0#{num_digits}i", 0)
         else
-          raise MARC::Exception.new("Can't write MARC record in binary format, as a length/offset value of #{number} is too long for a #{num_digits}-byte slot.")
+          raise Exception.new("Can't write MARC record in binary format, as a length/offset value of #{number} is too long for a #{num_digits}-byte slot.")
         end
       end
       return formatted

--- a/lib/marc/xml_parsers.rb
+++ b/lib/marc/xml_parsers.rb
@@ -17,7 +17,7 @@ module MARC
   # is arguable which is "best" on JRuby:  Nokogiri or jrexml.
   module MagicReader
     def self.extended(receiver)
-      magic = MARC::XMLReader.best_available
+      magic = XMLReader.best_available
       case magic
       when 'nokogiri' then receiver.extend(NokogiriReader)
       when 'libxml' then receiver.extend(LibXMLReader)
@@ -50,7 +50,7 @@ module MARC
       elsif @error_handler
         @error_handler.call(self, @record[:record], @block)
       else
-        raise MARC::RecordException, @record[:record]
+        raise RecordException, @record[:record]
       end
     ensure
       @record[:record] = nil
@@ -60,16 +60,16 @@ module MARC
       attributes = attributes_to_hash(attributes)
       if uri == @ns
         case name.downcase
-        when 'record' then @record[:record] = MARC::Record.new
+        when 'record' then @record[:record] = Record.new
         when 'leader' then @current_element = :leader
         when 'controlfield'
           @current_element = :field
-          @record[:field] = MARC::ControlField.new(attributes["tag"])
+          @record[:field] = ControlField.new(attributes["tag"])
         when 'datafield'
-          @record[:field] = MARC::DataField.new(attributes["tag"], attributes['ind1'], attributes['ind2'])
+          @record[:field] = DataField.new(attributes["tag"], attributes['ind1'], attributes['ind2'])
         when 'subfield'
           @current_element = :subfield
-          @record[:subfield] = MARC::Subfield.new(attributes['code'])
+          @record[:subfield] = Subfield.new(attributes['code'])
         end
       end
     end
@@ -211,7 +211,7 @@ module MARC
     # will accept parse events until a record has been built up
     #
     def build_record
-      record = MARC::Record.new
+      record = Record.new
       data_field = nil
       control_field = nil
       subfield = nil
@@ -243,17 +243,17 @@ module MARC
           when "controlfield"
             record << datafield if datafield
             datafield = nil
-            control_field = MARC::ControlField.new(node.attribute('tag'))
+            control_field = ControlField.new(node.attribute('tag'))
             record << control_field
             cursor = control_field
           when "datafield"
             record << datafield if datafield
             datafield = nil
-            data_field = MARC::DataField.new(node.attribute('tag'), node.attribute('ind1'), node.attribute('ind2'))
+            data_field = DataField.new(node.attribute('tag'), node.attribute('ind1'), node.attribute('ind2'))
             datafield = data_field
           when "subfield"
             raise "No datafield to add to" unless datafield
-            subfield = MARC::Subfield.new(node.attribute('code'))
+            subfield = Subfield.new(node.attribute('code'))
             datafield.append(subfield)
             cursor = subfield
           when "record"
@@ -278,14 +278,14 @@ module MARC
             case strip_ns(event[0])
             when 'controlfield'
               text = ''
-              control_field = MARC::ControlField.new(attrs['tag'])
+              control_field = ControlField.new(attrs['tag'])
             when 'datafield'
               text = ''
-              data_field = MARC::DataField.new(attrs['tag'], attrs['ind1'],
+              data_field = DataField.new(attrs['tag'], attrs['ind1'],
                                                attrs['ind2'])
             when 'subfield'
               text = ''
-              subfield = MARC::Subfield.new(attrs['code'])
+              subfield = Subfield.new(attrs['code'])
             end
           end
 
@@ -350,7 +350,7 @@ module MARC
       # each
 
       def build_record
-        r = MARC::Record.new()
+        r = Record.new()
         until (@parser.local_name == 'record' and @parser.node_type == XML::Reader::TYPE_END_ELEMENT) do
           @parser.read
           next if @parser.node_type == XML::Reader::TYPE_END_ELEMENT
@@ -361,16 +361,16 @@ module MARC
           when 'controlfield'
             tag = @parser['tag']
             @parser.read
-            r << MARC::ControlField.new(tag, @parser.value)
+            r << ControlField.new(tag, @parser.value)
           when 'datafield'
-            data = MARC::DataField.new(@parser['tag'], @parser['ind1'], @parser['ind2'])
+            data = DataField.new(@parser['tag'], @parser['ind1'], @parser['ind2'])
             while (@parser.read and !(@parser.local_name == 'datafield' and @parser.node_type == XML::Reader::TYPE_END_ELEMENT)) do
               next if @parser.node_type == XML::Reader::TYPE_END_ELEMENT
               case @parser.local_name
               when 'subfield'
                 code = @parser['code']
                 @parser.read
-                data.append(MARC::Subfield.new(code, @parser.value))
+                data.append(Subfield.new(code, @parser.value))
               end
             end
             r << data

--- a/lib/marc/xmlwriter.rb
+++ b/lib/marc/xmlwriter.rb
@@ -14,7 +14,7 @@ module MARC
     # or an object that responds to a write message
     # the second argument is a hash of options, currently
     # only supporting one option, stylesheet
-    # 
+    #
     # writer = XMLWriter.new 'marc.xml', :stylesheet => 'style.xsl'
     # writer.write record
 
@@ -42,7 +42,7 @@ module MARC
     # write a record to the file or handle
 
     def write(record)
-      @writer.write(MARC::XMLWriter.encode(record), @fh)
+      @writer.write(XMLWriter.encode(record), @fh)
       @fh.write("\n")
     end
 
@@ -94,7 +94,7 @@ module MARC
       e.add_element(leader)
 
       record.each do |field|
-        if field.class == MARC::DataField
+        if field.class == DataField
           datafield_elem = REXML::Element.new("datafield")
 
           # If marc is leniently parsed, we may have some dirty data; using
@@ -131,11 +131,11 @@ module MARC
           end
 
           e.add_element datafield_elem
-        elsif field.class == MARC::ControlField
+        elsif field.class == ControlField
           control_element = REXML::Element.new("controlfield")
 
           # We need a marker for invalid tag values (we use 000)
-          unless field.tag.match(ctrlFieldTag) or MARC::ControlField.control_tag?(ctrlFieldTag)
+          unless field.tag.match(ctrlFieldTag) or ControlField.control_tag?(ctrlFieldTag)
             field.tag = "00z"
           end
 


### PR DESCRIPTION
Let's say that I'm building a Rails application, and that I have a model named `MARC::Record`:
```ruby
class MARC::Record < ApplicationRecord
  # ...
end
```

If I want to use this gem, I'll be force to use another name for my model since there's already a class with same name in this library. 

However, I can alias the `MARC` namespace from this gem to another name (`RubyMARC` for example):
```ruby
require "marc"

RubyMARC = MARC

Object.send(:remove_const, :MARC)
```

This will allow me to reference the gem's code as `RubyMARC`, and keep using the `MARC` namespace in my Rails application:
```ruby
MARC::Record # => my code

RubyMARC::Record # => the gem's code
```
In order for that to be possible, the gem's code should use relative references instead of absolute references. So that a reference to `Record` inside `RubyMARC` resolves to `RubyMARC::Record` , and not to `MARC::Record`.