### PR TITLE
Prevent NoMethodError when comparing objects of different types

### DIFF
--- a/lib/marc/controlfield.rb
+++ b/lib/marc/controlfield.rb
@@ -53,6 +53,9 @@ module MARC
     # Two control fields are equal if their tags and values are equal.
 
     def ==(other)
+      if !other.is_a?(ControlField)
+        return false
+      end
       if @tag != other.tag
         return false
       elsif @value != other.value

--- a/lib/marc/datafield.rb
+++ b/lib/marc/datafield.rb
@@ -165,6 +165,9 @@ module MARC
     # subfields are all equal.
 
     def ==(other)
+      if !other.is_a?(DataField)
+        return false
+      end
       if @tag != other.tag
         return false
       elsif @indicator1 != other.indicator1

--- a/lib/marc/subfield.rb
+++ b/lib/marc/subfield.rb
@@ -1,9 +1,9 @@
 module MARC
 
-  # A class that represents an individual  subfield within a DataField. 
-  # Accessor attributes include: code (letter subfield code) and value 
-  # (the content of the subfield). Both can be empty string, but should 
-  # not be set to nil. 
+  # A class that represents an individual  subfield within a DataField.
+  # Accessor attributes include: code (letter subfield code) and value
+  # (the content of the subfield). Both can be empty string, but should
+  # not be set to nil.
 
   class Subfield
     attr_accessor :code, :value
@@ -16,6 +16,9 @@ module MARC
     end
 
     def ==(other)
+      if !other.is_a?(Subfield)
+        return false
+      end
       if @code != other.code
         return false
       elsif @value != other.value

--- a/test/tc_controlfield.rb
+++ b/test/tc_controlfield.rb
@@ -37,4 +37,18 @@ class TestField < Test::Unit::TestCase
     f = MARC::ControlField.new('245')
     assert_equal(f.valid?, false)
   end
+
+  def test_equal
+    f1 = MARC::ControlField.new('001', 'foobarbaz')
+    f2 = MARC::ControlField.new('001', 'foobarbaz')
+    assert_equal(f1, f2)
+
+    f3 = MARC::ControlField.new('001', 'foobarbazqux')
+    assert_not_equal(f1, f3)
+    f4 = MARC::ControlField.new('002', 'foobarbaz')
+    assert_not_equal(f1, f4)
+
+    assert_not_equal(f1, '001')
+    assert_not_equal(f2, 'foobarbaz')
+  end
 end

--- a/test/tc_datafield.rb
+++ b/test/tc_datafield.rb
@@ -67,4 +67,12 @@ class TestField < Test::Unit::TestCase
     assert_equal(f['b'], 'Bar')
   end
 
+  def test_equal_other_types
+    f = MARC::DataField.new('100', '0', '1',
+                             MARC::Subfield.new('a', 'Foo'),
+                             MARC::Subfield.new('b', 'Bar'))
+    assert_not_equal(f, "100 01 $a Foo $b Bar ")
+    assert_not_equal(f, f['a'])
+  end
+
 end

--- a/test/tc_subfield.rb
+++ b/test/tc_subfield.rb
@@ -13,6 +13,9 @@ class SubfieldTest < Test::Unit::TestCase
     s1 = MARC::Subfield.new('a', 'foo')
     s2 = MARC::Subfield.new('a', 'foo')
     assert_equal(s1, s2)
+
+    assert_not_equal(s1, 'a')
+    assert_not_equal(s1, 'foo')
   end
 
 end


### PR DESCRIPTION
Fixes #80.