### PR TITLE
JRubySTAXReader: support Java 9+ in CI, JRuby 9.3+ in general

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  # See https://github.com/jruby/jruby/issues/5509
+  JAVA_OPTS: "--add-opens java.xml/com.sun.org.apache.xerces.internal.impl=org.jruby.dist"
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+v1.1.2 (next)
+- Fix JRubySTAXReader to use :: syntax for constant access as required by
+  JRuby 9.3+.
+- Document JAVA_OPTS workaround for JRubySTAXReader module encapsulation
+  issue under Java 9+.
+- Deprecate JRubySTAXReader.
+
 v1.1.1 June 2021
 - Fix a regression when normalizing indicator values when serializing marcxml
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ using Nokogiri as an XML parser with JRuby as your ruby implementation, XML
 syntax errors will still be ignored unless you have Nokogiri version `1.10.2`
 or later.
 
+## JRubySTAXReader caveats
+
+- Under Java 9+, MARC::JRubySTAXReader requires adding the following to `JAVA_OPTS`
+  in order to work around [Java module system](https://openjdk.java.net/jeps/261) 
+  restrictions:
+
+  ```sh
+  --add-opens java.xml/com.sun.org.apache.xerces.internal.impl=org.jruby.dist
+  ```
+
+- MARC::JRubySTAXReader is deprecated and will be removed in a future version of
+  `ruby-marc`. Please use MARC::JREXMLReader or MARC::NokogiriReader instead.
+
 ## Miscellany 
 
 Source code at: https://github.com/ruby-marc/ruby-marc/

--- a/lib/marc/xml_parsers.rb
+++ b/lib/marc/xml_parsers.rb
@@ -411,13 +411,13 @@ module MARC
       end
 
       def parser_dispatch
-        while event = @parser.next and event != javax.xml.stream.XMLStreamConstants.END_DOCUMENT do
+        while event = @parser.next and event != javax.xml.stream.XMLStreamConstants::END_DOCUMENT do
           case event
-          when javax.xml.stream.XMLStreamConstants.START_ELEMENT
+          when javax.xml.stream.XMLStreamConstants::START_ELEMENT
             start_element_namespace(@parser.getLocalName, [], nil, @parser.getNamespaceURI, nil)
-          when javax.xml.stream.XMLStreamConstants.END_ELEMENT
+          when javax.xml.stream.XMLStreamConstants::END_ELEMENT
             end_element_namespace(@parser.getLocalName, @parser.getPrefix, @parser.getNamespaceURI)
-          when javax.xml.stream.XMLStreamConstants.CHARACTERS
+          when javax.xml.stream.XMLStreamConstants::CHARACTERS
             characters(@parser.getText)
           end
         end

--- a/lib/marc/xml_parsers.rb
+++ b/lib/marc/xml_parsers.rb
@@ -386,6 +386,9 @@ module MARC
   # of marc-xml. It includes most of the work from GenericPullParser
 
   if defined? JRUBY_VERSION
+    # *DEPRECATED*: JRubySTAXReader is deprecated and will be removed in a
+    # future version of ruby-marc. Please use JREXMLReader or NokogiriReader
+    # instead.
     module JRubySTAXReader
       include GenericPullParser
 
@@ -395,6 +398,8 @@ module MARC
       end
 
       def init
+        warn 'JRubySTAXReader is deprecated and will be removed in a future version of ruby-marc.'
+
         super
         @factory = javax.xml.stream.XMLInputFactory.newInstance
         @parser = @factory.createXMLStreamReader(@handle.to_inputstream)


### PR DESCRIPTION
- Add JAVA_OPTS to GitHub workflow to work around module access issue on Java 9+ (see [this comment on JRuby #5509](https://github.com/jruby/jruby/issues/5509#issuecomment-446855690))
- Use `::` syntax for constant access as required by JRuby 9.3+

Fixes #86 and #88.