### PR TITLE
Allow xml parsing to ignore namespace requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ marc is a ruby library for reading and writing MAchine Readable Cataloging
     writer = MARC::Writer.new('marc.dat')
     writer.write(record)
     writer.close()
+
+    # Reader for  MARC-XML, optionally specifying the parser to use
+    reader = MARC::XMLReader.new("myfile.xml", parser: :nokogiri)
+
+    # Reader for  MARC-XML, optionally specifying the parser to use,
+    # and not requiring the correct XML namespace to be present
+    reader = MARC::XMLReader.new("myfile.xml", parser: :nokogiri, ignore_namespace: true)
   
     # writing a record as XML
     writer = MARC::XMLWriter.new('marc.xml')

--- a/lib/marc/xml_parsers.rb
+++ b/lib/marc/xml_parsers.rb
@@ -58,7 +58,7 @@ module MARC
 
     def start_element_namespace name, attributes = [], prefix = nil, uri = nil, ns = {}
       attributes = attributes_to_hash(attributes)
-      if uri == @ns
+      if (uri == @ns) or @ignore_namespace
         case name.downcase
         when 'record' then @record[:record] = MARC::Record.new
         when 'leader' then @current_element = :leader
@@ -84,7 +84,7 @@ module MARC
 
     def end_element_namespace name, prefix = nil, uri = nil
       @current_element = nil
-      if uri == @ns
+      if (uri == @ns) or @ignore_namespace
         case name.downcase
         when 'record' then yield_record
         when 'leader'
@@ -260,7 +260,6 @@ module MARC
             record << datafield if datafield
             return record
           end
-          #puts node.name
         end
 
       else

--- a/lib/marc/xmlreader.rb
+++ b/lib/marc/xmlreader.rb
@@ -32,6 +32,13 @@ module MARC
   # or
   #   MARC::XMLReader.nokogiri!
   #
+  # By default, all XML parsers except REXML require the MARC namespace
+  # (http://www.loc.gov/MARC21/slim) to be included. Adding the option
+  # `ignore_namespace` to the call to `new` with a true value 
+  # will allow parsing to proceed,  e.g.,
+  #
+  #     reader = MARC::XMLReader.new(filename, parser: :nokogiri, ignore_namespace: true)
+  #
   # You can also pass in an error_handler option that will be called if
   # there are any validation errors found when parsing a record.
   #
@@ -58,6 +65,10 @@ module MARC
         raise ArgumentError, "must pass in path or File"
       end
       @handle = handle
+
+      if options[:ignore_namespace]
+        @ignore_namespace = options[:ignore_namespace]
+      end
 
       if options[:parser]
         parser = self.class.choose_parser(options[:parser].to_s)


### PR DESCRIPTION
Currently the REXML parser doesn't require the XML namespace, because REXML.
Many other libraries in other langugages (perl, PHP) will do the same.

Also, MARC::FastXMLWriter stupidly doesn't default to using the namespace, presumably because somewhere along the line I ran into one of these parsers that wouldn't support them. 

This PR adds a new optional keyword argument to `MARC::XMLReader.new`,
`ignore_namespace:`, which allows the XML pull-parsers to parse a
marc-xml file even in the absense of a correct namespace.

The default remains to not parse such files.