### PR TITLE
Add explicit support for jsonl marc-in-json files

### DIFF
--- a/lib/marc.rb
+++ b/lib/marc.rb
@@ -43,3 +43,6 @@ require File.dirname(__FILE__) + "/marc/xmlwriter"
 require File.dirname(__FILE__) + "/marc/xmlreader"
 require File.dirname(__FILE__) + "/marc/dublincore"
 require File.dirname(__FILE__) + "/marc/xml_parsers"
+
+require_relative "marc/jsonl_reader"
+require_relative "marc/jsonl_writer"

--- a/lib/marc/jsonl_reader.rb
+++ b/lib/marc/jsonl_reader.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "json"
+
+module MARC
+  # Read marc-in-json documents from a `.jsonl` file -- also called
+  # "newline-delimited JSON", which is a file with one JSON document on each line.
+  class JSONLReader
+    include Enumerable
+
+    # @param [String, IO] file A filename, or open File/IO type object, from which to read
+    def initialize(file)
+      if file.is_a?(String)
+        raise ArgumentError.new("File '#{file}' can't be found") unless File.exist?(file)
+        raise ArgumentError.new("File '#{file}' can't be opened for reading") unless File.readable?(file)
+        @handle = File.new(file)
+      elsif file.respond_to?(:read, 5)
+        @handle = file
+      else
+        raise ArgumentError, "must pass in path or file"
+      end
+    end
+
+    # Turn marc-in-json lines into actual marc records and yield them
+    # @yieldreturn [MARC::Record] record created from each line of the file
+    def each
+      return enum_for(:each) unless block_given?
+      @handle.each do |line|
+        yield MARC::Record.new_from_hash(JSON.parse(line))
+      end
+    end
+  end
+end

--- a/lib/marc/jsonl_writer.rb
+++ b/lib/marc/jsonl_writer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "json"
+require "marc/writer"
+
+module MARC
+  class JSONLWriter < MARC::Writer
+    # @param [String, IO] file A filename, or open File/IO type object, from which to read
+    def initialize(file)
+      if file.instance_of?(String)
+        @fh = File.new(file, "w:utf-8")
+      elsif file.respond_to?(:write)
+        @fh = file
+      else
+        raise ArgumentError, "must pass in file name or handle"
+      end
+    end
+
+    # Write encoded record to the handle
+    # @param [MARC::Record] record
+    # @return [MARC::JSONLWriter] self
+    def write(record)
+      @fh.puts(encode(record))
+      self
+    end
+
+    # Encode the record as a marc-in-json string
+    # @param [MARC::Record] record
+    # @return [String] MARC-in-JSON representation of the record
+    def self.encode(record)
+      JSON.fast_generate(record.to_hash)
+    end
+
+    # @see MARC::JSONLWriter.encode
+    def encode(rec)
+      self.class.encode(rec)
+    end
+  end
+end

--- a/lib/marc/record.rb
+++ b/lib/marc/record.rb
@@ -258,8 +258,6 @@ module MARC
       {"type" => "marc-hash", "version" => [MARCHASH_MAJOR_VERSION, MARCHASH_MINOR_VERSION], "leader" => leader, "fields" => map { |f| f.to_marchash }}
     end
 
-    # to_hash
-
     # Factory method for creating a new MARC::Record from
     # a marchash object
     #
@@ -284,6 +282,11 @@ module MARC
         record_hash["fields"] << field.to_hash
       end
       record_hash
+    end
+
+    # Return an actual json-encoded string.
+    def to_json_document
+      MARC::JSONLWriter.encode(self)
     end
 
     def self.new_from_hash(h)

--- a/test/tc_jsonl.rb
+++ b/test/tc_jsonl.rb
@@ -1,0 +1,19 @@
+require "test/unit"
+require "marc"
+
+class JSONLTestCase < Test::Unit::TestCase
+  def test_round_trip
+    tempfile = "test/batch.jsonl"
+    records = MARC::Reader.new("test/batch.dat").to_a
+    jsonl_writer = MARC::JSONLWriter.new(tempfile)
+    records.each { |r| jsonl_writer.write(r) }
+    jsonl_writer.close
+
+    jsonl_reader = MARC::JSONLReader.new(tempfile)
+    jsonl_reader.each_with_index do |r, i|
+      assert_equal(records[i], r)
+    end
+  ensure
+    File.unlink(tempfile)
+  end
+end


### PR DESCRIPTION
While it's obviously not hard to write the reader/writer
iterators for jsonl/newline-delimited-json files, folks
shouldn't have to do it over and over again.

* Add JSONLReader and JSONLWriter classes
* Add `MARC::Record#to_json_document` to keep the same
  api as we're adding with `MARC::Record.to_xml_document`