### PR TITLE
Allow writers to be given a block and self-close

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :test do
   gem "rdoc"
   gem "xml-simple"
   gem "test-unit"
-  gem 'warning'
+  gem "warning"
 end
 
 # Specify your gem's dependencies in ..gemspec

--- a/lib/marc/jsonl_writer.rb
+++ b/lib/marc/jsonl_writer.rb
@@ -6,13 +6,18 @@ require "marc/writer"
 module MARC
   class JSONLWriter < MARC::Writer
     # @param [String, IO] file A filename, or open File/IO type object, from which to read
-    def initialize(file)
+    def initialize(file, &blk)
       if file.instance_of?(String)
         @fh = File.new(file, "w:utf-8")
       elsif file.respond_to?(:write)
         @fh = file
       else
         raise ArgumentError, "must pass in file name or handle"
+      end
+
+      if blk
+        blk.call(self)
+        close
       end
     end
 

--- a/lib/marc/writer.rb
+++ b/lib/marc/writer.rb
@@ -28,7 +28,7 @@ module MARC
     # the constructor which you must pass a file path
     # or an object that responds to a write message
 
-    def initialize(file)
+    def initialize(file, &blk)
       if file.instance_of?(String)
         @fh = File.new(file, "w")
       elsif file.respond_to?(:write)
@@ -37,6 +37,11 @@ module MARC
         raise ArgumentError, "must pass in file name or handle"
       end
       self.allow_oversized = false
+
+      if block_given?
+        blk.call(self)
+        self.close
+      end
     end
 
     # write a record to the file or handle

--- a/lib/marc/xmlwriter.rb
+++ b/lib/marc/xmlwriter.rb
@@ -21,7 +21,7 @@ module MARC
       xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
       xsi:schemaLocation="#{MARC_NS} #{MARC_XSD}">).freeze
 
-    def initialize(file, opts = {})
+    def initialize(file, opts = {}, &blk)
       @writer = REXML::Formatters::Default.new
       if file.instance_of?(String)
         @fh = File.new(file, "w")
@@ -37,6 +37,11 @@ module MARC
       @fh.write(stylesheet_tag)
       @fh.write(COLLECTION_TAG)
       @fh.write("\n")
+
+      if block_given?
+        blk.call(self)
+        self.close
+      end
     end
 
     def stylesheet_tag


### PR DESCRIPTION
Much like `File.open("myfile.txt", "w:utf-8") {|file| file.puts "Hello"}` will
close itself after running the block, this changes the MARC::*Writer classes to
do the same. One can now do:

```ruby
MARC::Writer.new("myfile.dat") do |writer|
  writer.write(record)
end

```

...and the writer will automatically close itself.
