### PR TITLE
Allow passing of custom MARC::Record-derived class to readers

### DIFF
--- a/lib/marc/datafield.rb
+++ b/lib/marc/datafield.rb
@@ -19,6 +19,11 @@ module MARC
   class DataField
     include Enumerable
 
+    # The subfield class
+    def self.subfield_class
+      MARC::Subfield
+    end
+
     # The tag for the field
     attr_accessor :tag
 

--- a/lib/marc/generic_reader.rb
+++ b/lib/marc/generic_reader.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class MARC::GenericReader
+
+  include Enumerable
+
+  attr_reader :record_class, :control_class, :data_class, :subfield_class
+
+  # The constructor which you may pass either a path
+  #
+  #   reader = MARC::Reader.new('marc.dat')
+  #
+  # or, if it's more convenient a File object:
+  #
+  #   fh = File.new('marc.dat')
+  #   reader = MARC::Reader.new(fh)
+  #
+  # or really any object that responds to read(n)
+  #
+  #   # marc is a string with a bunch of records in it
+  #   reader = MARC::Reader.new(StringIO.new(marc))
+  #
+  # If your data have non-standard control fields in them
+  # (e.g., Aleph's 'FMT') you need to add them specifically
+  # to the MARC::ControlField.control_tags Set object
+  #
+  #   MARC::ControlField.control_tags << 'FMT'
+  #
+  def initialize(file, record_class: MARC::Record)
+    @record_class = record_class
+
+    if file.is_a?(String)
+      raise ArgumentError.new("File '#{file}' can't be found") unless File.exist?(file)
+      raise ArgumentError.new("File '#{file}' can't be opened for reading") unless File.readable?(file)
+      @handle = File.new(file)
+    elsif file.respond_to?(:read, 5)
+      @handle = file
+    else
+      raise ArgumentError, "must pass in path or file, not `#{file.inspect}`"
+    end
+  end
+
+
+end

--- a/lib/marc/jsonl_reader.rb
+++ b/lib/marc/jsonl_reader.rb
@@ -1,32 +1,18 @@
 # frozen_string_literal: true
 
+require_relative "generic_reader"
 require "json"
 
 module MARC
   # Read marc-in-json documents from a `.jsonl` file -- also called
   # "newline-delimited JSON", which is a file with one JSON document on each line.
-  class JSONLReader
-    include Enumerable
-
-    # @param [String, IO] file A filename, or open File/IO type object, from which to read
-    def initialize(file)
-      if file.is_a?(String)
-        raise ArgumentError.new("File '#{file}' can't be found") unless File.exist?(file)
-        raise ArgumentError.new("File '#{file}' can't be opened for reading") unless File.readable?(file)
-        @handle = File.new(file)
-      elsif file.respond_to?(:read, 5)
-        @handle = file
-      else
-        raise ArgumentError, "must pass in path or file"
-      end
-    end
-
+  class JSONLReader < GenericReader
     # Turn marc-in-json lines into actual marc records and yield them
     # @yieldreturn [MARC::Record] record created from each line of the file
     def each
       return enum_for(:each) unless block_given?
       @handle.each do |line|
-        yield MARC::Record.new_from_hash(JSON.parse(line))
+        yield record_class.new_from_hash(JSON.parse(line))
       end
     end
   end

--- a/test/tc_custom_record.rb
+++ b/test/tc_custom_record.rb
@@ -1,0 +1,25 @@
+require "test/unit"
+require "marc"
+
+class TestCustomRecord < Test::Unit::TestCase
+
+  module SimpleMARCSemantics
+    def title
+      self["245"].select { |sf| %w(a b d e k f g n p).include?(sf.code) }
+                 .map { |sf| sf.value }
+                 .join(" ")
+                 .gsub(/[\s\/;.,]+\Z/, '')
+    end
+  end
+
+  class MyRecord < MARC::Record
+    include SimpleMARCSemantics
+  end
+
+  def test_basics
+    reader = MARC::ForgivingReader.new("test/batch.dat", record_class: MyRecord)
+    rec = reader.first
+    assert_equal("ActivePerl with ASP and ADO", rec.title)
+  end
+
+end

--- a/test/tc_reader.rb
+++ b/test/tc_reader.rb
@@ -11,9 +11,7 @@ class ReaderTest < Test::Unit::TestCase
 
   def test_loose
     reader = MARC::ForgivingReader.new("test/batch.dat")
-    count = 0
-    reader.each { count += 1 }
-    assert_equal(10, count)
+    assert_equal(10, reader.count)
   end
 
   def test_loose_utf8


### PR DESCRIPTION
[Currently looking for input]

The use of MARC::Record is hard-coded into the various readers, when really any duck-typed alternative would be fine.  It'd be nice to be able to do something like this:

```ruby

class MyMarc < MARC::Record
  include MySpecialSnowflakeLibraryStuff
  include SomePublicModuleOfStandardIdentifierStuff
end

reader = MARC::XMLReader.new("/path/to/file.xml", record_class: MyMarc)
reader.each do |rec|
  puts "OCLCs: #{rec.oclcs.join(", ")}"
  puts "Locations: #{rec.shelf_locations.join(", ")}"
end

```

While not impossible, it's currently hard for people to develop local customizations to the record object (to, e.g., get the sublibraries that hold a monograph), the only options being to build external methods/functions to extract the data (e.g., `get_oclcs(rec)`, instead of `rec.oclcs`), monkey-patch (ugh!), or run a `rec.extend` or something for each record.

In the same vein, the current `MARC::Record` implementation is driven largely by the needs of those of us who are more than willing to trade memory use and initialization time in order to make many reads from a record slightly faster. If anyone else would rather make different tradeoffs they have no options at all.

This non-breaking change allows passing in a `record_class:` keyword argument to the readers, which will then use that class to build records instead of a vanilla MARC::Record.

Most of the actual characters of change are changing old-school `params` could-be-a-has-could-look-like-keywords method parameters into real keyword params or something equivalent (e.g., `**params`), which is messy because of all the encoding stuff.

The substantive changes are just adding the keyword argument with its default and then using that record_class to derive classes to construct the control fields and data fields, and use the latter to get a class for constructing subfields. A few changes from, e.g., `MARC::DataField` to `data_class` are sprinkled where needed. 
