### PR TITLE
Allow readers to take a custom Record class

### DIFF
--- a/lib/marc/jsonl_reader.rb
+++ b/lib/marc/jsonl_reader.rb
@@ -9,7 +9,11 @@ module MARC
     include Enumerable
 
     # @param [String, IO] file A filename, or open File/IO type object, from which to read
-    def initialize(file)
+    def initialize(file, record_class: MARC::Record)
+      @record_class = record_class
+      if file.is_a? Pathname
+        file = file.to_s
+      end
       if file.is_a?(String)
         raise ArgumentError.new("File '#{file}' can't be found") unless File.exist?(file)
         raise ArgumentError.new("File '#{file}' can't be opened for reading") unless File.readable?(file)
@@ -26,7 +30,7 @@ module MARC
     def each
       return enum_for(:each) unless block_given?
       @handle.each do |line|
-        yield MARC::Record.new_from_hash(JSON.parse(line))
+        yield @record_class.new_from_hash(JSON.parse(line))
       end
     end
   end

--- a/lib/marc/reader.rb
+++ b/lib/marc/reader.rb
@@ -190,7 +190,8 @@ module MARC
     #
     #   reader = MARC::Reader.new(File.new('marc.dat', 'r:cp866'))
     def initialize(file, options = {})
-      @encoding_options = {}
+      @record_class = options[:record_class] || MARC::Record
+      @encoding_options = {record_class: @record_class}
       # all can be nil
       [:internal_encoding, :external_encoding, :invalid, :replace, :validate_encoding].each do |key|
         @encoding_options[key] = options[key] if options.has_key?(key)
@@ -227,7 +228,7 @@ module MARC
     def each
       if block_given?
         each_raw do |raw|
-          record = decode(raw)
+          record = decode(raw, record_class: @record_class)
           yield record
         end
       else
@@ -278,8 +279,8 @@ module MARC
     #
     # Wraps the class method MARC::Reader::decode, using the encoding options of
     # the MARC::Reader instance.
-    def decode(marc)
-      MARC::Reader.decode(marc, @encoding_options)
+    def decode(marc, record_class: @record_class)
+      MARC::Reader.decode(marc, @encoding_options.merge({record_class: record_class}))
     end
 
     # A static method for turning raw MARC data in transission
@@ -290,6 +291,7 @@ module MARC
     #   [:forgiving]          needs more docs, true is some kind of forgiving
     #                         of certain kinds of bad MARC.
     def self.decode(marc, params = {})
+      record_class = params[:record_class] || MARC::Record
       if params.has_key?(:encoding)
         warn "DEPRECATION WARNING: MARC::Reader.decode :encoding option deprecated, please use :external_encoding"
         params[:external_encoding] = params.delete(:encoding)
@@ -305,7 +307,7 @@ module MARC
       # and want to avoid byte-vs-char confusion.
       marc.force_encoding("binary") if marc.respond_to?(:force_encoding)
 
-      record = Record.new
+      record = record_class.new
       record.leader = marc[0..LEADER_LENGTH - 1]
 
       # where the field data starts
@@ -368,10 +370,8 @@ module MARC
         # add a control field or data field
         if MARC::ControlField.control_tag?(tag)
           field_data = MARC::Reader.set_encoding(field_data, params)
-          record.append(MARC::ControlField.new(tag, field_data))
+          record.append_control_field(tag, field_data)
         else
-          field = MARC::DataField.new(tag)
-
           # get all subfields
           subfields = field_data.split(SUBFIELD_INDICATOR)
 
@@ -381,18 +381,15 @@ module MARC
 
           # get indicators
           indicators = MARC::Reader.set_encoding(subfields.shift, params)
-          field.indicator1 = indicators[0, 1]
-          field.indicator2 = indicators[1, 1]
+          ind1 = indicators[0]
+          ind2 = indicators[1]
 
-          # add each subfield to the field
-          subfields.each do |data|
-            data = MARC::Reader.set_encoding(data, params)
-            subfield = MARC::Subfield.new(data[0, 1], data[1..-1])
-            field.append(subfield)
+          # Get subfields as [code, data] pairs
+          subfield_pairs = subfields.map do |raw_data|
+            data = MARC::Reader.set_encoding(raw_data, params)
+            [data[0], data[1..-1]]
           end
-
-          # add the field to the record
-          record.append(field)
+          record.append_data_field(tag, ind1, ind2, subfield_pairs)
         end
       end
 

--- a/lib/marc/record.rb
+++ b/lib/marc/record.rb
@@ -132,6 +132,24 @@ module MARC
       @fields.flat_map(&:errors)
     end
 
+    def self.create_data_field(tag, ind1, ind2, subfields)
+      DataField.new(tag, ind1, ind2, *subfields)
+    end
+
+    def self.create_control_field(tag, value)
+      ControlField.new(tag, value)
+    end
+
+    def append_data_field(tag, ind1, ind2, subfields)
+      append(self.class.create_data_field(tag, ind1, ind2, subfields))
+      @fields.clean = false
+    end
+
+    def append_control_field(tag, data)
+      append(self.class.create_control_field(tag, data))
+      @fields.clean = false
+    end
+
     # add a field to the record
     #   record.append(MARC::DataField.new( '100', '2', '0', ['a', 'Fred']))
 
@@ -267,7 +285,7 @@ module MARC
 
     # Return a marc-hash version of the record
     def to_marchash
-      {"type" => "marc-hash", "version" => [MARCHASH_MAJOR_VERSION, MARCHASH_MINOR_VERSION], "leader" => leader, "fields" => map { |f| f.to_marchash }}
+      { "type" => "marc-hash", "version" => [MARCHASH_MAJOR_VERSION, MARCHASH_MINOR_VERSION], "leader" => leader, "fields" => map { |f| f.to_marchash } }
     end
 
     # Factory method for creating a new MARC::Record from
@@ -279,9 +297,13 @@ module MARC
       r = new
       r.leader = mh["leader"]
       mh["fields"].each do |f|
-        if f.length == 2
-          r << MARC::ControlField.new(f[0], f[1])
-        elsif r << MARC::DataField.new(f[0], f[1], f[2], *f[3])
+        case f.length
+        when 2
+          r.append_control_field(f.first, f.last)
+        when 4
+          r.append_data_field(f[0], f[1], f[2], f[3])
+        else
+          raise MARC::Exception.new("Illegal field array: #{f}")
         end
       end
       r
@@ -289,7 +311,7 @@ module MARC
 
     # Returns a (roundtrippable) hash representation for MARC-in-JSON
     def to_hash
-      record_hash = {"leader" => @leader, "fields" => []}
+      record_hash = { "leader" => @leader, "fields" => [] }
       @fields.each do |field|
         record_hash["fields"] << field.to_hash
       end
@@ -307,15 +329,10 @@ module MARC
       h["fields"]&.each do |position|
         position.each_pair do |tag, field|
           if field.is_a?(Hash)
-            f = MARC::DataField.new(tag, field["ind1"], field["ind2"])
-            field["subfields"].each do |pos|
-              pos.each_pair do |code, value|
-                f.append MARC::Subfield.new(code, value)
-              end
-            end
-            r << f
+            subfields = field["subfields"].map{|sf| sf.to_a.first}
+            r.append_data_field(tag, field["ind1"], field["ind2"], subfields)
           else
-            r << MARC::ControlField.new(tag, field)
+            r.append_control_field(tag, field)
           end
         end
       end

--- a/lib/marc/xmlreader.rb
+++ b/lib/marc/xmlreader.rb
@@ -65,6 +65,8 @@ module MARC
       end
       @handle = handle
 
+      @record_class = options[:record_class] || MARC::Record
+
       if options[:ignore_namespace]
         @ignore_namespace = options[:ignore_namespace]
       end

--- a/test/tc_reader.rb
+++ b/test/tc_reader.rb
@@ -106,4 +106,16 @@ class ReaderTest < Test::Unit::TestCase
     9.times { enum.next } # total of ten records
     assert_raises(StopIteration) { enum.next }
   end
+
+  class MyRecord < MARC::Record
+    def hello
+      "hello"
+    end
+  end
+  def test_different_record_class
+    reader = MARC::Reader.new("test/batch.dat", record_class: MyRecord)
+    r = reader.first
+    assert_instance_of(MyRecord, r)
+    assert_equal("hello", r.hello)
+  end
 end

--- a/test/tc_xml.rb
+++ b/test/tc_xml.rb
@@ -190,4 +190,16 @@ class XMLTest < Test::Unit::TestCase
       assert_equal(record.leader, "01301nam a22003618< 4500", "Failed with parser '#{parser}'")
     end
   end
+
+  class MyRecord < MARC::Record
+    def hello
+      "hello"
+    end
+  end
+  def test_different_record_class
+    reader = MARC::XMLReader.new("test/batch.xml", parser: :nokogiri, record_class: MyRecord)
+    r = reader.first
+    assert_instance_of(MyRecord, r)
+    assert_equal("hello", r.hello)
+  end
 end


### PR DESCRIPTION
Most uses of a MARC record require extraction of things like OCLC numbers, local identifiers, etc. The ruby-marc reader classes hard-code the use of MARC::Record, which means folks who want to do that either need to inline their code, wrap a MARC::Record object, or call
the reader.

This code allows the binary reader and the non-REXML XML readers to take a `record_class` option. The
required interface is for the passed class is:

* `#append_control_field(tag, value)`
* `#append_data_field(tag, ind1, ind2, subfields)` where `subfields` is an array of [code, value] pairs
* `#leader` and `#leader=`
* `#new_from_hash(marc_hash)` which is used in the XML reader to avoid using specific field classes

All the rest of the code has been modified to use just those methods when building up a record.

The easiest way to take advantage of this would be to just subclass MARC::Record, e.g.

```
class MyRecord < MARC::Record
  def isbns
    m = /[\d\-Xx]{10,15}/
    fields('020').map{|f| f['a'].scan(m).first.gsub('-', '').upcase}
  end
end

r = MARC::Reader.new("test/batch.dat", record_class: MyRecord).first
r.isbns #=> ["0471383147"]

```