### PR TITLE
Remove unf

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, jruby]
+        ruby: [3.0, 3.1, 3.2, 3.3, jruby]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,7 @@
 source "https://rubygems.org"
 
 group :test do
-  if RUBY_VERSION != "1.8.7"
-    gem "nokogiri"
-  end
+  gem "nokogiri"
   gem "rake"
   gem "rdoc"
   gem "xml-simple"

--- a/lib/marc/marc8/to_unicode.rb
+++ b/lib/marc/marc8/to_unicode.rb
@@ -1,6 +1,5 @@
 require "marc"
 require "marc/marc8/map_to_unicode"
-require "unf/normalizer"
 
 module MARC
   module Marc8
@@ -170,7 +169,7 @@ module MARC
         end
 
         if normalization
-          uni_str = UNF::Normalizer.normalize(uni_str, normalization)
+          uni_str = uni_str.unicode_normalize(normalization)
         end
 
         uni_str

--- a/lib/marc/reader.rb
+++ b/lib/marc/reader.rb
@@ -1,5 +1,3 @@
-require "scrub_rb"
-
 # Note: requiring 'marc/marc8/to_unicode' below, in #initialize,
 # only when necessary
 

--- a/marc.gemspec
+++ b/marc.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/ruby-marc/ruby-marc/"
   s.summary = "A ruby library for working with Machine Readable Cataloging"
   s.license = "MIT"
-  s.required_ruby_version = ">= 1.8.6"
+  s.required_ruby_version = ">= 2.2.0"
   s.authors = ["Kevin Clarke", "Bill Dueber", "William Groppe", "Jonathan Rochkind", "Ross Singer", "Ed Summers", "Chris Beer"]
 
   s.files = `git ls-files -z`.split("\x0")
@@ -17,7 +17,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "standard", "~>1.0"
-  s.add_dependency "scrub_rb", ">= 1.0.1", "< 2" # backport for ruby 2.1 String#scrub
-  s.add_dependency "unf" # unicode normalization
   s.add_dependency "rexml" # rexml was unbundled from the stdlib in ruby 3
 end

--- a/test/marc8/tc_to_unicode.rb
+++ b/test/marc8/tc_to_unicode.rb
@@ -3,8 +3,6 @@ require "marc"
 
 require "marc/marc8/to_unicode"
 
-require "unf"
-
 if "".respond_to?(:encoding)
 
   class TestMarc8ToUnicode < Test::Unit::TestCase
@@ -22,7 +20,7 @@ if "".respond_to?(:encoding)
       value = MARC::Marc8::ToUnicode.new.transcode("Conversa\xF0c\xE4ao")
       assert_equal "UTF-8", value.encoding.name
 
-      expected = UNF::Normalizer.normalize("Conversação", :nfc)
+      expected = "Conversação".unicode_normalize(:nfc)
 
       assert_equal expected, value
     end
@@ -67,10 +65,10 @@ if "".respond_to?(:encoding)
       marc8 = "Conversa\xF0c\xE4ao \xC1"
       unicode = "Conversação \u2113"
 
-      unicode_c = UNF::Normalizer.normalize(unicode, :nfc)
-      unicode_kc = UNF::Normalizer.normalize(unicode, :nfkc)
-      unicode_d = UNF::Normalizer.normalize(unicode, :nfd)
-      unicode_kd = UNF::Normalizer.normalize(unicode, :nfkd)
+      unicode_c = unicode.unicode_normalize(:nfc)
+      unicode_kc = unicode.unicode_normalize(:nfkc)
+      unicode_d = unicode.unicode_normalize(:nfd)
+      unicode_kd = unicode.unicode_normalize(:nfkd)
 
       converter = MARC::Marc8::ToUnicode.new
 


### PR DESCRIPTION
Currently, `rubymarc` fails to install in a `Gemfile` unless `rake` is also included in that `Gemfile`.

This is because of this issue in unf 0.2.0: https://github.com/knu/ruby-unf/issues/24

However, unf is no longer necessary with rubies more recent than 2.2, as `String#unicode_normalize` covers this functionality. Indeed, unf 0.2.0 delegates to `String#unicode_normalize` when available.

This PR removes support for ruby < 2.2 (all unsupported for over 8 years at this point), and updates the test matrix to test against more recent versions of Ruby.